### PR TITLE
Import ::Unicode.const_missing to rex/text/unicode

### DIFF
--- a/lib/rex/text/unicode.rb
+++ b/lib/rex/text/unicode.rb
@@ -274,3 +274,27 @@ module Rex
 
   end
 end
+
+# from http://dzone.com/snippets/convert-unicode-codepoints-utf
+
+# This module lazily defines constants of the form Uxxxx for all Unicode
+# codepoints from U0000 to U10FFFF. The value of each constant is the
+# UTF-8 string for the codepoint.
+# Examples:
+#   copyright = Unicode::U00A9
+#   euro = Unicode::U20AC
+#   infinity = Unicode::U221E
+#
+module ::Unicode
+  def self.const_missing(name)
+    # Check that the constant name is of the right form: U0000 to U10FFFF
+    if name.to_s =~ /^U([0-9a-fA-F]{4,5}|10[0-9a-fA-F]{4})$/
+      # Convert the codepoint to an immutable UTF-8 string,
+      # define a real constant for that value and return the value
+      #p name, name.class
+      const_set(name, [$1.to_i(16)].pack("U").freeze)
+    else  # Raise an error for constants that are not Unicode.
+      raise NameError, "Uninitialized constant: Unicode::#{name}"
+    end
+  end
+end


### PR DESCRIPTION
This delta was generated from the SVIT fork's version of rex/text.
Git blame shows this diff to be part of 0e3b1585 on 20130430.
Other changes have been omitted as they do not pertain to upstream
imports of the fork's functional changes.

Commit message indicates this to be part of the Powershell cleanup
effort during one of the merges upstream, and designed to deal with
parsing foreign PSH scripts containing aberrant characters.

---

This implementation alters a root namespace, using a const_set method, which isn't ideal. Does it make sense to implement the method as a local extension of the namespace within Rex::Text, or dynamically alter the execution context in ::Unicode at runtime from blocks which deal with strange characters?
