### PR TITLE
Stop ascii_safe_hex() from crashing on UTF-8 strings

### DIFF
--- a/lib/rex/text/hex.rb
+++ b/lib/rex/text/hex.rb
@@ -1,4 +1,3 @@
-# -*- coding: binary -*-
 module Rex
   module Text
     # We are re-opening the module to add these module methods.
@@ -112,9 +111,14 @@ module Rex
     # @see to_hex Converts all the chars
     #
     def self.ascii_safe_hex(str, whitespace=false)
+      # This sanitization is terrible and breaks everything if it finds unicode.
+      # ~4 Billion can't be wrong; long-term, this should be removed.
+      if str.encoding == (::Encoding::UTF_8)
+        return str
+      end
       if whitespace
         str.gsub(/([\x00-\x20\x80-\xFF])/n){ |x| "\\x%.2x" % x.unpack("C*")[0] }
-      else
+        else
         str.gsub(/([\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xFF])/n){ |x| "\\x%.2x" % x.unpack("C*")[0]}
       end
     end

--- a/lib/rex/text/hex.rb
+++ b/lib/rex/text/hex.rb
@@ -118,7 +118,7 @@ module Rex
       end
       if whitespace
         str.gsub(/([\x00-\x20\x80-\xFF])/n){ |x| "\\x%.2x" % x.unpack("C*")[0] }
-        else
+      else
         str.gsub(/([\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xFF])/n){ |x| "\\x%.2x" % x.unpack("C*")[0]}
       end
     end


### PR DESCRIPTION
This PR changes the behavior of the data sanitization function that converts bad ANSI chars into hex values.  Predictably, it goes south quick when presented with UTF-8.

This sanitization did not target characters associated with SQL injection or other attacks, only chars 0x00-0x20 and above 0x80.... so there appears to be no security motive, just preventing any non-printable ANSI characters from entering the database.