### PR TITLE
Remove dead code, fix typo

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -140,7 +140,7 @@ module Rex
     def self.converge_sets(sets, idx, offsets, length) # :nodoc:
       buf = sets[idx][offsets[idx]].chr
 
-      # If there are more sets after use, converage with them.
+      # If there are more sets after use, converge with them.
       if (sets[idx + 1])
         buf << converge_sets(sets, idx + 1, offsets, length)
       else

--- a/lib/rex/text/pattern.rb
+++ b/lib/rex/text/pattern.rb
@@ -33,14 +33,7 @@ module Rex
       sets.length.times { offsets << 0 }
 
       until buf.length >= length
-        begin
           buf << converge_sets(sets, 0, offsets, length)
-        end
-      end
-
-      # Maximum permutations reached, but we need more data
-      if (buf.length < length)
-        buf = buf * (length / buf.length.to_f).ceil
       end
 
       buf[0,length]


### PR DESCRIPTION
Some code in `pattern_create()` smells dead to me, and in testing I couldn't get it to light up. If we're concerned about performance of generating huge patterns, it might be better to `converge_sets()` only once and cycle its output. I can try my hand at that if it's decided to be useful.
