### PR TITLE
Fix padding for Unicode strings

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -400,7 +400,14 @@ protected
     # Ensure we pad the minimum required amount
     max = colprops[colidx]['MaxChar'] || colprops[colidx]['MaxWidth']
     max = colprops[colidx]['MaxWidth'] if max.to_i > colprops[colidx]['MaxWidth'].to_i
-    remainder = max - buf.length
+
+    encoding = buf.encoding.name
+    if not ["UTF-8", "ASCII-8BIT", "US-ASCII"].include? encoding
+      warn '**WARNING** In file #{__FILE__}::pad : String with unsupported encoding caught!'
+    end
+    utf8_buf = buf.dup.force_encoding("UTF-8")
+
+    remainder = max - utf8_buf.length
     remainder = 0 if remainder < 0
     val       = chr * remainder
 


### PR DESCRIPTION
This resolves issue [#7500](https://github.com/rapid7/metasploit-framework/issues/7500) in `metasploit-framework`.

As suggested on that thread, all text is converted to UTF-8 on entering the `pad` function. A check on the encoding ensures graceful exit if an unexpected encoding (like UTF-16 or UTF-32) is encountered.