### PR TITLE
handle comparing ipv4 and ipv6

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -205,6 +205,8 @@ class Table
         cmp = -1
       elsif !(a[index].kind_of?(IPAddr) || b[index].kind_of?(IPAddr)) && (valid_ip?(a[index]) && valid_ip?(b[index]))
         cmp = IPAddr.new(a[index]) <=> IPAddr.new(b[index])
+        # comparing IPv4 with IPv6 results in nil, and doesn't make sense anyway, so fudge it
+        cmp ||= 0
       else
         cmp = a[index] <=> b[index] # assumes otherwise comparable.
       end


### PR DESCRIPTION
This arose from this issue: https://github.com/rapid7/metasploit-framework/issues/7988

This only happens when IPs are passed in as String objects and one is IPv4 and the other is IPv6. Not sure this is the most elegant fix, but for the frequency with which this will ever happen, it might be good enough.