### PR TITLE
Update lang.rb: Allow longer VBA lines

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -125,7 +125,7 @@ module Rex
 
       code  = str.unpack('C*')
       buff = "#{name} = Array("
-      maxbytes = 20
+      maxbytes = 80
 
       1.upto(code.length) do |idx|
         buff << code[idx].to_s


### PR DESCRIPTION
Avoids errors in Visual Basic for Applications. Closes https://github.com/rapid7/metasploit-framework/issues/8147. 

More background:
https://msdn.microsoft.com/en-us/library/office/gg264236.aspx

The VBA format limits line continuations to 25. There are a few methods that can be used: http://stackoverflow.com/questions/2806151/excel-macros-too-many-line-continuations

This is the hackiest solution that actually works. Really long payloads will need a better fix (one of the ones from Stack Overflow would do nicely), but 80 bytes fits windows/meterpreter/reverse_https in only nine lines out of a maximum of 25.