### PR TITLE
Rubinius compiler does not like fun

### DIFF
--- a/lib/rex/text/block_api.rb
+++ b/lib/rex/text/block_api.rb
@@ -13,10 +13,10 @@ module Rex
     # @param fun [String] The name of the function.
     #
     # @return [String] The hash of the mod/fun pair in string format
-    def self.block_api_hash(mod, fun)
+    def self.block_api_hash(mod, func)
       unicode_mod = (mod.upcase + "\x00").unpack('C*').pack('v*')
       mod_hash = self.ror13_hash(unicode_mod)
-      fun_hash = self.ror13_hash(fun + "\x00")
+      fun_hash = self.ror13_hash(func + "\x00")
       "0x#{(mod_hash + fun_hash & 0xFFFFFFFF).to_s(16)}"
     end
 


### PR DESCRIPTION
Seems that "fun" is a keyword which the RBX compiler does not like.

Change block_api.rb to use "func" instead.

Addresses:
```
                                  main # Rubinius::Loader at core/loader.rb:861
                                script # Rubinius::Loader at core/loader.rb:679
                           load_script . Rubinius::CodeLoader at core/code_loader.rb:590
                           load_script # Rubinius::CodeLoader at core/code_loader.rb:505
                            __script__ # Object at msfconsole:49
                               require # Kernel(Object) at core/kernel.rb:851
                               require . Rubinius::CodeLoader at core/code_loader.rb:233
                            __script__ # Object at lib/msf/core/payload_generator.rb:2
                               require # Kernel(Object) at core/kernel.rb:851
                               require . Rubinius::CodeLoader at core/code_loader.rb:233
                            __script__ # Object at lib/msf/core/payload/apk.rb:3
                               require # Kernel(Object) at core/kernel.rb:851
                               require . Rubinius::CodeLoader at core/code_loader.rb:233
                            __script__ # Object at lib/msf/core.rb:18
      require (require_with_backports) # Kernel(Object) at vendor/rbx/rbx/2.3/gems/backports-3.8.0/lib/backports/std_lib.rb:9
   require_without_backports (require) # Kernel(Object) at core/kernel.rb:851
                               require . Rubinius::CodeLoader at core/code_loader.rb:233
                            __script__ # Object at lib/rex.rb:46
      require (require_with_backports) # Kernel(Object) at vendor/rbx/rbx/2.3/gems/backports-3.8.0/lib/backports/std_lib.rb:9
   require_without_backports (require) # Kernel(Object) at core/kernel.rb:851
                               require . Rubinius::CodeLoader at core/code_loader.rb:233
                            __script__ # Object at vendor/rbx/rbx/2.3/bundler/gems/rex-text-4a611e135429/lib/rex/text.rb:23
      require (require_with_backports) # Kernel(Object) at vendor/rbx/rbx/2.3/gems/backports-3.8.0/lib/backports/std_lib.rb:9
   require_without_backports (require) # Kernel(Object) at core/kernel.rb:851
                               require . Rubinius::CodeLoader at core/code_loader.rb:227
                               require # Rubinius::CodeLoader at core/code_loader.rb:128
                             load_file # Rubinius::CodeLoader at core/code_loader.rb:628
                          compile_file # Rubinius::CodeLoader at core/code_loader.rb:655
                               compile . CodeTools::Compiler at /usr/lib/rubinius/runtime/gems/rubinius-compiler-3.10/lib/rubinius/code/compiler/compiler.rbc:89
                                   run # CodeTools::Compiler at /usr/lib/rubinius/runtime/gems/rubinius-compiler-3.10/lib/rubinius/code/compiler/compiler.rbc:359
                                   run # CodeTools::Compiler::Parser(CodeTools::Compiler::FileParser) at 
        /usr/lib/rubinius/runtime/gems/rubinius-compiler-3.10/lib/rubinius/code/compiler/stages.rbc:207
                                 parse # CodeTools::Compiler::FileParser at /usr/lib/rubinius/runtime/gems/rubinius-compiler-3.10/lib/rubinius/code/compiler/stages.rbc:225
                            parse_file # CodeTools::Melbourne at /usr/lib/rubinius/runtime/gems/rubinius-melbourne-3.9/lib/rubinius/code/melbourne.rbc:61
                          syntax_error # CodeTools::Melbourne at /usr/lib/rubinius/runtime/gems/rubinius-melbourne-3.9/lib/rubinius/code/melbourne.rbc:48

A syntax error has occurred:
    syntax error, unexpected keyword_fun: /opt/metasploit/vendor/rbx/rbx/2.3/bundler/gems/rex-text-4a611e135429/lib/rex/text/block_api.rb:16:36

Code:
    def self.block_api_hash(mod, fun)
                                   ^
```
And for those who remember this from last time, yes, back at it - the GIL is our enemy!