### PR TITLE
simplify shuffle_a implementation

### DIFF
--- a/lib/rex/text/randomize.rb
+++ b/lib/rex/text/randomize.rb
@@ -83,18 +83,7 @@ module Rex
     # @param arr [Array] The array to be shuffled
     # @return [Array]
     def self.shuffle_a(arr)
-      len = arr.length
-      max = len - 1
-      cyc = [* (0..max) ]
-      for d in cyc
-        e = rand(d+1)
-        next if e == d
-        f = arr[d];
-        g = arr[e];
-        arr[d] = g;
-        arr[e] = f;
-      end
-      return arr
+      arr.shuffle!
     end
 
     # Permute the case of a word


### PR DESCRIPTION
The #shuffle! method uses the Fisher-Yates algorithm.

I think this will do the job just as well, if not better?

Same benchmark I shared in https://github.com/rapid7/rex-text/pull/15
```ruby
require "benchmark/ips"

def fast
  arr = [*1..100]
  arr.shuffle! 
end

def slow
  arr = [*1..100]
  len = arr.length
  max = len - 1
  cyc = [* (0..max) ]
  for d in cyc
    e = rand(d+1)
    next if e == d
    f = arr[d];
    g = arr[e];
    arr[d] = g;
    arr[e] = f;
  end
  return arr
end

Benchmark.ips do |x|
  x.report("slower") { slow }
  x.report("faster") { fast }
  x.compare!
end
```

```
Warming up --------------------------------------
              slower     2.457k i/100ms
              faster    13.637k i/100ms
Calculating -------------------------------------
              slower     25.076k (± 4.9%) i/s -    125.307k in   5.009132s
              faster    160.511k (± 4.1%) i/s -    804.583k in   5.021311s

Comparison:
              faster:   160510.8 i/s
              slower:    25076.0 i/s - 6.40x  slower
```
