### PR TITLE
speedup to_mixed_case_array method

### DIFF
--- a/lib/rex/text/randomize.rb
+++ b/lib/rex/text/randomize.rb
@@ -35,18 +35,14 @@ module Rex
     # @return [Array<String>]
     # @see permute_case
     def self.to_mixed_case_array(str)
-      letters = []
-      str.scan(/./).each { |l| letters << [l.downcase, l.upcase] }
-      coords = []
-      (1 << str.size).times { |i| coords << ("%0#{str.size}b" % i) }
-      mixed = []
-      coords.each do |coord|
-        c = coord.scan(/./).map {|x| x.to_i}
+      letters = str.each_char.map { |l| [l.downcase, l.upcase] }
+      (1 << str.size).times.map do |i| 
         this_str = ""
-        c.each_with_index { |d,i| this_str << letters[i][d] }
-        mixed << this_str
-      end
-      return mixed.uniq
+        ("%0#{str.size}b" % i).each_char.map(&:to_i).each_with_index do |d,i|
+          this_str << letters[i][d]
+        end
+        this_str
+      end.uniq
     end
 
     #


### PR DESCRIPTION
By removing regex and utilizing maps to limit unnecessary allocation allows for some performance gains for the [`to_mixed_case_array` ](https://github.com/rapid7/rex-text/blob/master/lib/rex/text/randomize.rb#L37) method.

## Benchmark
```ruby
require "benchmark/ips"

def fast
  str = "abc1"
  letters = str.each_char.map { |l| [l.downcase, l.upcase] }
  (1 << str.size).times.map do |i| 
    this_str = ""
    ("%0#{str.size}b" % i).each_char.map(&:to_i).each_with_index do |d,i|
      this_str << letters[i][d]
    end
    this_str
  end.uniq
end

def slow
  str = "abc1"
  letters = []
  str.scan(/./).each { |l| letters << [l.downcase, l.upcase] }
  coords = []
  (1 << str.size).times { |i| coords << ("%0#{str.size}b" % i) }
  mixed = []
  coords.each do |coord|
    c = coord.scan(/./).map {|x| x.to_i}
    this_str = ""
    c.each_with_index { |d,i| this_str << letters[i][d] }
    mixed << this_str
  end
  return mixed.uniq
end

Benchmark.ips do |x|
  x.report("slower") { slow }
  x.report("faster") { fast }
  x.compare!
end
```

```
Warming up --------------------------------------
              slower     1.002k i/100ms
              faster     1.205k i/100ms
Calculating -------------------------------------
              slower     10.040k (± 4.6%) i/s -     50.100k in   5.000814s
              faster     12.467k (± 4.2%) i/s -     62.660k in   5.035032s

Comparison:
              faster:    12467.2 i/s
              slower:    10039.9 i/s - 1.24x  slower
```

Basically 1.2x faster ( in my benchmarks ) 👍 
