### PR TITLE
use single regular expression for strict case

### DIFF
--- a/lib/rex/text/binary_manipulation.rb
+++ b/lib/rex/text/binary_manipulation.rb
@@ -58,9 +58,8 @@ module Rex
     # strict - include *only* words, no boundary characters (like spaces, etc.)
     #
     def self.to_words( str, strict = false )
-      splits = str.split( /\b/ )
-      splits.reject! { |w| !(w =~ /\w/) } if strict
-      splits
+      return str.split(/\b/) unless strict
+      str.scan(/\w+/)
     end
 
     #


### PR DESCRIPTION
Instead of using type regular expressions and a map to reject out the words we don’t want, we can just as easily use one regular expression yielding a 5x speed bump in my benchmarks.

```ruby
require "benchmark/ips"

def fast
  str = "Ain't no party like a scranton party, cuz a scranton party don't stop! "
  strict = true

  return str.split(/\b/) unless strict
  str.scan(/\w+/)
end

def slow
  str = "Ain't no party like a scranton party, cuz a scranton party don't stop! "
  strict = true
  
  splits = str.split( /\b/ )
  splits.reject! { |w| !(w =~ /\w/) } if strict                                                             
  splits
end

puts fast == slow

Benchmark.ips do |x|
  x.report("slower") { slow }
  x.report("faster") { fast }
  x.compare!
end
```
```
true
Warming up --------------------------------------
              slower     2.828k i/100ms
              faster    14.655k i/100ms
Calculating -------------------------------------
              slower     31.773k (± 7.8%) i/s -    158.368k in   5.017034s
              faster    163.505k (± 4.4%) i/s -    820.680k in   5.029305s

Comparison:
              faster:   163505.2 i/s
              slower:    31772.7 i/s - 5.15x  slower
```
