### PR TITLE
remove unnecessary gsub regex to remove newline

### DIFF
--- a/lib/rex/text/base64.rb
+++ b/lib/rex/text/base64.rb
@@ -10,8 +10,12 @@ module Rex
     #
     # Base64 encoder
     #
-    def self.encode_base64(str)
-      [str.to_s].pack("m").strip
+    def self.encode_base64(str, delim=nil)
+      if delim
+        [str.to_s].pack("m").gsub(/\s+/, delim)
+      else
+        [str.to_s].pack("m0")
+      end
     end
 
     #
@@ -24,8 +28,8 @@ module Rex
     #
     # Base64 encoder (URL-safe RFC6920)
     #
-    def self.encode_base64url(str)
-      encode_base64(str).
+    def self.encode_base64url(str, delim=nil)
+      encode_base64(str, delim).
         tr('+/', '-_').
         gsub('=', '')
     end

--- a/lib/rex/text/base64.rb
+++ b/lib/rex/text/base64.rb
@@ -10,8 +10,8 @@ module Rex
     #
     # Base64 encoder
     #
-    def self.encode_base64(str, delim='')
-      [str.to_s].pack("m").gsub(/\s+/, delim)
+    def self.encode_base64(str)
+      [str.to_s].pack("m").strip
     end
 
     #
@@ -24,8 +24,8 @@ module Rex
     #
     # Base64 encoder (URL-safe RFC6920)
     #
-    def self.encode_base64url(str, delim='')
-      encode_base64(str, delim).
+    def self.encode_base64url(str)
+      encode_base64(str).
         tr('+/', '-_').
         gsub('=', '')
     end


### PR DESCRIPTION
Using the strip method gives the same result and is up to 5x faster in my benchmarks. This also simplifies the base64 encoding API ( removing the delim argument ):

```ruby
require "benchmark/ips"
require "pry"

def fast
  str = "I love Ruby programming!"
  [str.to_s].pack("m").strip
end

def slow
  str = "I love Ruby programming!"
  delim = ""

  [str.to_s].pack("m").gsub(/\s+/, delim)
end

puts fast == slow

Benchmark.ips do |x|
  x.report("slower") { slow }
  x.report("faster") { fast }
  x.compare!
end
```
```
true
Warming up --------------------------------------
              slower    22.861k i/100ms
              faster    92.001k i/100ms
Calculating -------------------------------------
              slower    261.858k (± 3.7%) i/s -      1.326M in   5.070992s
              faster      1.291M (± 4.5%) i/s -      6.532M in   5.068937s

Comparison:
              faster:  1291425.5 i/s
              slower:   261858.0 i/s - 4.93x  slower
```
