### PR TITLE
optimize default case for to_hex method

### DIFF
--- a/lib/rex/text/hex.rb
+++ b/lib/rex/text/hex.rb
@@ -16,6 +16,8 @@ module Rex
     # @param count [Integer] Number of bytes to put in each escape chunk
     # @return [String] The escaped hex version of +str+
     def self.to_hex(str, prefix = "\\x", count = 1)
+      return str.each_byte.map { |byte| prefix + byte.to_s(16) }.join if count == 1
+      
       raise ::RuntimeError, "unable to chunk into #{count} byte chunks" if ((str.length % count) > 0)
 
       # XXX: Regexp.new is used here since using /.{#{count}}/o would compile


### PR DESCRIPTION
On the default use case for this method (that is, using the default arguments) we can avoid using Regex for a decent speed bump while retaining the method’s flexibility when needed.

Roughly a `1.5`x speed bump.

```ruby
require "benchmark/ips"

def fast
  str = "Ain't no party like a scranton party cuz a scranton party don't stop"
  prefix = "\\x"
  count = 1

  return str.each_byte.map { |byte| prefix + byte.to_s(16) }.join if count == 1
  raise ::RuntimeError, "unable to chunk into #{count} byte chunks" if ((str.length % count) > 0)                                                    
  return str.unpack('H*')[0].gsub(Regexp.new(".{#{count * 2}}", nil, 'n')) { |s| prefix + s }
end

def slow
  str = "Ain't no party like a scranton party cuz a scranton party don't stop"
  prefix = "\\x"
  count = 1

  raise ::RuntimeError, "unable to chunk into #{count} byte chunks" if ((str.length % count) > 0)                                                    
  return str.unpack('H*')[0].gsub(Regexp.new(".{#{count * 2}}", nil, 'n')) { |s| prefix + s }
end

puts fast == slow

Benchmark.ips do |x|
  x.report("slower") { slow }
  x.report("faster") { fast }
  x.compare!
end
```

```
true
Warming up --------------------------------------
              slower     2.320k i/100ms
              faster     3.749k i/100ms
Calculating -------------------------------------
              slower     23.508k (± 3.3%) i/s -    118.320k in   5.038901s
              faster     39.210k (± 3.1%) i/s -    198.697k in   5.072537s

Comparison:
              faster:    39209.7 i/s
              slower:    23507.5 i/s - 1.67x  slower
```