### PR TITLE
Implement XOR with variable-length key

### DIFF
--- a/lib/rex/text/xor.rb
+++ b/lib/rex/text/xor.rb
@@ -7,32 +7,26 @@ module Rex::Text
   # @param value [String] String to XOR
   # @return [String] XOR'd string
   def self.xor(key, value)
-    # Check for nil
     unless key && value
       raise ArgumentError, 'XOR key and value must be supplied'
     end
 
     xor_key =
-      begin
-        # Support integer strings
-        Integer(key)
-      rescue ArgumentError
+      case key
+      when String
+        if key.empty?
+          raise ArgumentError, 'XOR key must not be empty'
+        end
+
         key
+      when Integer
+        unless key.between?(0, 255)
+          raise ArgumentError, 'XOR key must be between 0x00 and 0xff'
+        end
+
+        # Convert integer to string
+        [key].pack('C')
       end
-
-    if xor_key.is_a?(Integer)
-      unless xor_key.between?(0, 255)
-        raise ArgumentError, 'XOR key must be between 0x00 and 0xff'
-      end
-
-      # Convert integer to string
-      xor_key = [xor_key].pack('C')
-    end
-
-    # Check for empty strings
-    if xor_key.empty? || value.empty?
-      raise ArgumentError, 'XOR key and value must not be empty'
-    end
 
     # Get byte arrays for key and value
     xor_key   = xor_key.bytes

--- a/lib/rex/text/xor.rb
+++ b/lib/rex/text/xor.rb
@@ -1,28 +1,39 @@
 # -*- coding: binary -*-
 
-module Rex
-  module Text
-
-    # Returns a XOR'd string.
-    #
-    # @param key [String] XOR key.
-    # @param value [String] The string to XOR.
-    # @return [String] An XOR'd string.
-    def self.xor(key, value)
-      xor_key = key.kind_of?(Integer) || key.nil? ? key.to_i : key.to_i(16)
-      unless xor_key.between?(0, 255)
-        raise ArgumentError, 'XOR key should be between 0x00 to 0x0f'
-      end
-
-      buf = ''
-
-      value.each_byte do |byte|
-        xor_byte = byte ^ xor_key
-        buf << [xor_byte].pack('c')
-      end
-
-      buf
+module Rex::Text
+  # XOR a string against a variable-length key
+  #
+  # @param key [String] XOR key
+  # @param value [String] String to XOR
+  # @return [String] XOR'd string
+  def self.xor(key, value)
+    # Check for nil
+    unless key && value
+      raise ArgumentError, 'XOR key and value must be supplied'
     end
 
+    xor_key =
+      begin
+        # Support integer strings
+        Integer(key)
+      rescue ArgumentError
+        key
+      end
+
+    if xor_key.is_a?(Integer)
+      unless xor_key.between?(0, 255)
+        raise ArgumentError, 'XOR key must be between 0x00 and 0xff'
+      end
+
+      # Convert integer to string
+      xor_key = [xor_key].pack('C')
+    end
+
+    # Get byte arrays for key and value
+    xor_key   = xor_key.bytes
+    xor_value = value.bytes
+
+    # XOR value against cycled key
+    xor_value.zip(xor_key.cycle).map { |v, k| v ^ k }.pack('C*')
   end
 end

--- a/lib/rex/text/xor.rb
+++ b/lib/rex/text/xor.rb
@@ -20,7 +20,7 @@ module Rex::Text
 
         key
       when Integer
-        unless key.between?(0, 255)
+        unless key.between?(0x00, 0xff)
           raise ArgumentError, 'XOR key must be between 0x00 and 0xff'
         end
 

--- a/lib/rex/text/xor.rb
+++ b/lib/rex/text/xor.rb
@@ -29,6 +29,11 @@ module Rex::Text
       xor_key = [xor_key].pack('C')
     end
 
+    # Check for empty strings
+    if xor_key.empty? || value.empty?
+      raise ArgumentError, 'XOR key and value must not be empty'
+    end
+
     # Get byte arrays for key and value
     xor_key   = xor_key.bytes
     xor_value = value.bytes

--- a/spec/rex/text/xor_spec.rb
+++ b/spec/rex/text/xor_spec.rb
@@ -18,11 +18,6 @@ describe Rex::Text do
       expect(Rex::Text.xor(xor_key, hello_world_str)).to eq(xor_hello_world_str)
     end
 
-    it 'XORs with a string type key' do
-      xor_key = "0x0f"
-      expect(Rex::Text.xor(xor_key, hello_world_str)).to eq(xor_hello_world_str)
-    end
-
     it 'XORs with a variable-length key' do
       xor_key = "\x00\x00\x00\x00\x00\x0c"
       expect(Rex::Text.xor(xor_key, hello_world_str)).to eq('hello,world')

--- a/spec/rex/text/xor_spec.rb
+++ b/spec/rex/text/xor_spec.rb
@@ -23,6 +23,16 @@ describe Rex::Text do
       expect(Rex::Text.xor(xor_key, hello_world_str)).to eq(xor_hello_world_str)
     end
 
+    it 'XORs with a variable-length key' do
+      xor_key = "\x00\x00\x00\x00\x00\x0c"
+      expect(Rex::Text.xor(xor_key, hello_world_str)).to eq('hello,world')
+    end
+
+    it 'raises an ArgumentError due to a nil key' do
+      bad_key = nil
+      expect { Rex::Text.xor(bad_key, hello_world_str) }.to raise_error(ArgumentError)
+    end
+
     it 'raises an ArgumentError due to an out of range key' do
       bad_key = 0x1024
       expect { Rex::Text.xor(bad_key, hello_world_str) }.to raise_error(ArgumentError)

--- a/spec/rex/text/xor_spec.rb
+++ b/spec/rex/text/xor_spec.rb
@@ -38,6 +38,11 @@ describe Rex::Text do
       expect { Rex::Text.xor(bad_key, hello_world_str) }.to raise_error(ArgumentError)
     end
 
+    it 'raises an ArgumentError due to an empty key' do
+      bad_key = ''
+      expect { Rex::Text.xor(bad_key, hello_world_str) }.to raise_error(ArgumentError)
+    end
+
     it 'raises an ArgumentError due to an out of range key' do
       bad_key = 0x1024
       expect { Rex::Text.xor(bad_key, hello_world_str) }.to raise_error(ArgumentError)

--- a/spec/rex/text/xor_spec.rb
+++ b/spec/rex/text/xor_spec.rb
@@ -28,6 +28,11 @@ describe Rex::Text do
       expect(Rex::Text.xor(xor_key, hello_world_str)).to eq('hello,world')
     end
 
+    it 'XORs with itself' do
+      xor_key = hello_world_str
+      expect(Rex::Text.xor(xor_key, hello_world_str)).to eq("\x00" * hello_world_str.length)
+    end
+
     it 'raises an ArgumentError due to a nil key' do
       bad_key = nil
       expect { Rex::Text.xor(bad_key, hello_world_str) }.to raise_error(ArgumentError)


### PR DESCRIPTION
This removes support for integer strings, which don't work well with variable-length key strings.

```
[1] pry(#<Msf::Framework>)> Rex::Text.xor(0x0f, 'hello world')
=> "gjcc`/x`}ck"
[2] pry(#<Msf::Framework>)> Rex::Text.to_hex(Rex::Text.xor('0x0f', 'hello world'), '')
=> "581d5c0a5f584709421454"
[3] pry(#<Msf::Framework>)> Rex::Text.xor("\x00\x00\x00\x00\x00\x0c", 'hello world')
=> "hello,world"
[4] pry(#<Msf::Framework>)>
```

```
wvu@kharak:~$ xortool-xor -h 0f -s "hello world"
gjcc`/x`}ck
wvu@kharak:~$ xortool-xor -r 0x0f -s "hello world" | tr -d "\n" | xxd -p
581d5c5f584709421454
wvu@kharak:~$ xortool-xor -s "\x00\x00\x00\x00\x00\x0c" -s "hello world"
hello,world
wvu@kharak:~$
```