### PR TITLE
fix python3 bytes string

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -63,7 +63,7 @@ module Rex
     # Converts a raw string into a python buffer
     #
     def self.to_python(str, wrap = DefaultWrap, name = "buf")
-      return hexify(str, wrap, "#{name} += \"", '"', "#{name} =  \"\"\n", '"')
+      return hexify(str, wrap, "#{name} += b\"", '"', "#{name} =  b\"\"\n", '"')
     end
 
     #


### PR DESCRIPTION
Just a tiny fix to make the python formatted payload work for both python2 and python3.
By default python3 uses unicode strings, so by adding the `b` prefix it will interpret the string as raw bytes.