### PR TITLE
Set prompt escape chars only when they work

### DIFF
--- a/lib/rex/text/color.rb
+++ b/lib/rex/text/color.rb
@@ -52,7 +52,7 @@ module Color
   def substitute_colors(msg, in_prompt = nil)
     str = msg.dup
     pre_color = post_color = ''
-    if (in_prompt)
+    if (in_prompt && supports_color?)
       pre_color = "\x01"  # RL_PROMPT_START_IGNORE
       post_color = "\x02" # RL_PROMPT_END_IGNORE
     end


### PR DESCRIPTION
An alternate fix for https://github.com/rapid7/metasploit-framework/pull/13489

Verification
=========
- [ ] Point framework to your local rex-text checkout
- [ ] Start the web service and create a console (see the [original PR](https://github.com/rapid7/metasploit-framework/pull/13489))
- [ ] Verify the console prompt doesn't have escape characters in it