### PR TITLE
Fix for vbapplication payload generation

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -127,7 +127,7 @@ module Rex
       buff = "#{name} = Array("
       maxbytes = 80
 
-      1.upto(code.length) do |idx|
+      0.upto(code.length) do |idx|
         buff << code[idx].to_s
         buff << "," if idx < code.length - 1
         buff << " _\r\n" if (idx > 1 and (idx % maxbytes) == 0)

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -127,7 +127,7 @@ module Rex
       buff = "#{name} = Array("
       maxbytes = 80
 
-      0.upto(code.length) do |idx|
+      0.upto(code.length-1) do |idx|
         buff << code[idx].to_s
         buff << "," if idx < code.length - 1
         buff << " _\r\n" if (idx > 1 and (idx % maxbytes) == 0)


### PR DESCRIPTION
There seems to be a problem with vbapplication payload generation. The loop starts at 1, so the first byte is lost. This fix resolves this issue.