### PR TITLE
CRC32C Checksum Calculator Function Added

### DIFF
--- a/lib/rex/text/crc32_block_api.rb
+++ b/lib/rex/text/crc32_block_api.rb
@@ -1,0 +1,25 @@
+# -*- coding: binary -*-
+require 'crc'
+
+module Rex
+    module Text
+      # We are re-opening the module to add these module methods.
+      # Breaking them up this way allows us to maintain a little higher
+      # degree of organisation and make it easier to find what you're looking for
+      # without hanging the underlying calls that we historically rely upon.
+  
+      #
+      # Calculate the CRC32 block API checksum for the given module/function
+      #
+      # @param mod [String] The name of the module containing the target function.
+      # @param fun [String] The name of the function.
+      #
+      # @return [String] The checksum of the mod/fun pair in string format
+      def self.crc32_block_api_checksum(mod, func)
+        crc32c = CRC.new(32, 0x11EDC6F41, initial_crc = 0, refin = true, refout = true, xor_output = 0)
+        unicode_mod = (mod.upcase + "\x00").unpack('C*').pack('v*')
+        "0x#{(crc32c[unicode_mod+func+"\x00"]).to_s(16)}"
+      end
+    end
+  end
+  


### PR DESCRIPTION
Hello,

Following up on the new [CRC32 block API](https://github.com/rapid7/metasploit-framework/pull/13762) PR. As mentioned i added a new `crc32_block_api_checksum` function for calculating the CRC32 (polynomial 11EDC6F41H) checksum values of the given `[MODULE_NAME+NULL+FUNCTION_NAME]`. For testing/comparing the generated values you can use [crc32_checksum.py](https://github.com/rapid7/metasploit-framework/blob/6aeaf1f52b592b62a9c9f5de949afa993486ffc3/external/source/shellcode/windows/x86/src/crc32_checksum.py) script.  