### PR TITLE
Also check the IO.console is not nil before wrapping based on its width

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -21,7 +21,7 @@ class Table
   # To enforce all tables to be wrapped to the terminal's current width, call `Table.wrap_tables!`
   # before invoking `Table.new` as normal.
   def self.new(*args, &block)
-    if wrap_tables?
+    if wrap_tables? && !::IO.console.nil?
       table_options = args[0]
       return ::Rex::Text::WrappedTable.new(table_options)
     end


### PR DESCRIPTION
This fixes a stack trace where if `IO.console` is nil, the WrappedTable will fail to generate leading to stacktraces instead of output within `msfconsole`. I came across this when debugging Metasploit with RubyMine and running the `jobs` command. The proposed solution is to check if `::IO.console` is nil before wrapping tables based on its width. If the width isn't available from the console, then there's probably no point in automatically wrapping tables.

Example stack trace:
```
msf6 exploit(windows/smb/psexec) > jobs
[-] Error while running command jobs: undefined method `winsize' for nil:NilClass

Call stack:
/home/smcintyre/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/rex-text-0.2.28/lib/rex/text/wrapped_table.rb:74:in `initialize'
/home/smcintyre/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/rex-text-0.2.28/lib/rex/text/table.rb:26:in `new'
/home/smcintyre/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/rex-text-0.2.28/lib/rex/text/table.rb:26:in `new'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/base/serializer/readable_text.rb:964:in `dump_jobs'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/jobs.rb:172:in `cmd_jobs'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:476:in `block in run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:470:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:470:in `run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:158:in `run'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
/home/smcintyre/Repositories/metasploit-framework/msfconsole:23:in `<top (required)>'
/home/smcintyre/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/ruby-debug-ide-2.3.0/lib/ruby-debug-ide.rb:100:in `debug_load'
/home/smcintyre/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/ruby-debug-ide-2.3.0/lib/ruby-debug-ide.rb:100:in `debug_program'
/home/smcintyre/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/ruby-debug-ide-2.3.0/bin/rdebug-ide:204:in `<main>'
msf6 exploit(windows/smb/psexec) > 
```

I'm not sure under what other conditions `::IO.console` will be nil, so your best bet might be to reproduce this using RubyMine and the console within the debugger.