### PR TITLE
Revert "Also check the IO.console is not nil before wrapping based on its width"

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -21,7 +21,7 @@ class Table
   # To enforce all tables to be wrapped to the terminal's current width, call `Table.wrap_tables!`
   # before invoking `Table.new` as normal.
   def self.new(*args, &block)
-    if wrap_tables? && !::IO.console.nil?
+    if wrap_tables?
       table_options = args[0]
       return ::Rex::Text::WrappedTable.new(table_options)
     end


### PR DESCRIPTION
Reverts rapid7/rex-text#34

Looks like this change breaks in Jenkins CI, reverting for now :+1: