### PR TITLE
Allow per table configuration of wrapped tables

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -21,15 +21,22 @@ class Table
   # To enforce all tables to be wrapped to the terminal's current width, call `Table.wrap_tables!`
   # before invoking `Table.new` as normal.
   def self.new(*args, &block)
-    if wrap_tables?
-      table_options = args[0]
+    if wrap_table?(args)
+      table_options = args.first
       return ::Rex::Text::WrappedTable.new(table_options)
     end
     return super(*args, &block)
   end
 
-  def self.wrap_tables?
-    @@wrapped_tables_enabled ||= false
+  def self.wrap_table?(args)
+    return false unless wrapped_tables?
+
+    table_options = args.first
+    if table_options&.key?('WordWrap')
+      return table_options['WordWrap']
+    end
+
+    wrapped_tables?
   end
 
   def self.wrap_tables!
@@ -38,6 +45,10 @@ class Table
 
   def self.unwrap_tables!
     @@wrapped_tables_enabled = false
+  end
+
+  def self.wrapped_tables?
+    @@wrapped_tables_enabled ||= false
   end
 
   #

--- a/spec/rex/text/table_spec.rb
+++ b/spec/rex/text/table_spec.rb
@@ -22,6 +22,39 @@ describe Rex::Text::Table do
     Styler.new
   end
 
+  describe '.wrap_table?' do
+    let(:default_table_options) { [{ }] }
+    let(:wrapped_table_options) { [{ 'WrapTable' => true }] }
+    let(:feature_enabled) { false }
+
+    before(:each) do
+      allow(described_class).to receive(:wrapped_tables?).and_return(feature_enabled)
+    end
+
+    context 'when the feature is enabled' do
+      let(:feature_enabled) { true }
+
+      it "defaults to true" do
+        expect(described_class.wrap_table?(default_table_options)).to be true
+      end
+
+      it "ignores the user preference" do
+        expect(described_class.wrap_table?(wrapped_table_options)).to be true
+      end
+    end
+
+    context 'when the feature is disabled' do
+      let(:feature_enabled) { false }
+
+      it "defaults to false" do
+        expect(described_class.wrap_table?(default_table_options)).to be false
+      end
+
+      it "ignores the user preference" do
+        expect(described_class.wrap_table?(wrapped_table_options)).to be false
+      end
+    end
+  end
 
   it 'should space columns correctly' do
     col_1_field = "A" * 5

--- a/spec/rex/text/wrapped_table_spec.rb
+++ b/spec/rex/text/wrapped_table_spec.rb
@@ -68,7 +68,7 @@ describe Rex::Text::Table do
 
   before(:each) do
     allow(::IO).to receive(:console).and_return(mock_io_console)
-    allow(Rex::Text::Table).to receive(:wrap_tables?).and_return(true)
+    allow(Rex::Text::Table).to receive(:wrap_table?).with(anything).and_return(true)
   end
 
   describe "#to_csv" do


### PR DESCRIPTION
Let's update the API to allow opting out of wrapped tables on a per table basis with the option:

```
'WordWrap'   => false,
```