### PR TITLE
 Add rand_password method to Rex::Text

### DIFF
--- a/lib/rex/text/rand.rb
+++ b/lib/rex/text/rand.rb
@@ -260,7 +260,7 @@ module Rex
     end
 
     # Generate a strong password of specified length and attributes
-    def self.rand_password(len=10, mix_case:true, special_characters: false)
+    def self.rand_password(len=10, mix_case:true, numbers:true, special_characters: false)
       allowed_characters=[]
       upper=('A'..'Z').to_a
       lower=('a'..'z').to_a

--- a/lib/rex/text/rand.rb
+++ b/lib/rex/text/rand.rb
@@ -266,9 +266,7 @@ module Rex
       lower=('a'..'z').to_a
       number=('0'..'10').to_a
       specials = ((32..47).to_a + (58..64).to_a + (91..96).to_a + (123..126).to_a).pack('U*').chars
-      if uppercase
-        allowed_characters+=upper
-      end
+      allowed_characters+=upper
       if mix_case
         allowed_characters+=lower
       end

--- a/lib/rex/text/rand.rb
+++ b/lib/rex/text/rand.rb
@@ -258,5 +258,27 @@ module Rex
       mail_address << '@'
       mail_address << Rex::Text.rand_hostname
     end
+
+    # Generate a strong password of specified length and attributes
+    def self.rand_password(len=10, uppercase=true, lowercase=true, numbers=true, special=true)
+      foo=[]
+      upper=('A'..'Z').to_a
+      lower=('a'..'z').to_a
+      number=('0'..'10').to_a
+      specials = ((32..47).to_a + (58..64).to_a + (91..96).to_a + (123..126).to_a).pack('U*').chars
+      if uppercase
+        foo+=upper
+      end
+      if lowercase
+        foo+=lower
+      end
+      if numbers
+        foo+=number
+      end
+      if special
+      	foo+=specials
+      end
+      rand_base(len,'',*foo)
+    end
   end
 end

--- a/lib/rex/text/rand.rb
+++ b/lib/rex/text/rand.rb
@@ -273,7 +273,7 @@ module Rex
       if numbers
         allowed_characters+=number
       end
-      if special
+      if special_characters
         allowed_characters+=specials
       end
       rand_base(len,'',*allowed_characters)

--- a/lib/rex/text/rand.rb
+++ b/lib/rex/text/rand.rb
@@ -260,25 +260,25 @@ module Rex
     end
 
     # Generate a strong password of specified length and attributes
-    def self.rand_password(len=10, uppercase=true, lowercase=true, numbers=true, special=false)
-      foo=[]
+    def self.rand_password(len=10, mix_case:true, special_characters: false)
+      allowed_characters=[]
       upper=('A'..'Z').to_a
       lower=('a'..'z').to_a
       number=('0'..'10').to_a
       specials = ((32..47).to_a + (58..64).to_a + (91..96).to_a + (123..126).to_a).pack('U*').chars
       if uppercase
-        foo+=upper
+        allowed_characters+=upper
       end
-      if lowercase
-        foo+=lower
+      if mix_case
+        allowed_characters+=lower
       end
       if numbers
-        foo+=number
+        allowed_characters+=number
       end
       if special
-      	foo+=specials
+        allowed_characters+=specials
       end
-      rand_base(len,'',*foo)
+      rand_base(len,'',*allowed_characters)
     end
   end
 end

--- a/lib/rex/text/rand.rb
+++ b/lib/rex/text/rand.rb
@@ -260,7 +260,7 @@ module Rex
     end
 
     # Generate a strong password of specified length and attributes
-    def self.rand_password(len=10, uppercase=true, lowercase=true, numbers=true, special=true)
+    def self.rand_password(len=10, uppercase=true, lowercase=true, numbers=true, special=false)
       foo=[]
       upper=('A'..'Z').to_a
       lower=('a'..'z').to_a


### PR DESCRIPTION
Fix #12110

Adds rand_password method which can be used to generate password of desired length and custom attributes for uppercase, lowercase, numbers and special characters.

This PR was created in response to issue [#12110](https://github.com/rapid7/metasploit-framework/issues/12110) on Metasploit-Framework.