### PR TITLE
Table: Show selected row indicator in indent margin if sufficient space

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -118,6 +118,9 @@ class Table
     self.sort_index  = opts['SortIndex'] || 0
     self.sort_order  = opts['SortOrder'] || :forward
 
+    self.selected_index = opts['SelectedIndex']
+    self.selected_row_prefix = opts['SelectedRowPrefix'] || '*'
+
     # Default column properties
     self.columns.length.times { |idx|
       self.colprops[idx] = {}
@@ -153,11 +156,22 @@ class Table
     str << hr_to_s || ''
 
     sort_rows
-    rows.each { |row|
+    selected_row_prefix = self.selected_row_prefix || ''
+
+    rows.each_with_index { |row, idx|
       if (is_hr(row))
         str << hr_to_s
+        next
+      end
+
+      next unless row_visible(row)
+
+      if idx == self.selected_index && selected_row_prefix.length <= indent
+        r = row_to_s(row)
+        r[indent - (selected_row_prefix.length), selected_row_prefix.length] = selected_row_prefix
+        str << r
       else
-        str << row_to_s(row) if row_visible(row)
+        str << row_to_s(row)
       end
     }
 
@@ -361,6 +375,7 @@ class Table
   attr_accessor :width, :indent, :cellpad # :nodoc:
   attr_accessor :prefix, :postfix # :nodoc:
   attr_accessor :sort_index, :sort_order, :scterm # :nodoc:
+  attr_accessor :selected_index, :selected_row_prefix # :nodoc:
 
 protected
 

--- a/lib/rex/text/wrapped_table.rb
+++ b/lib/rex/text/wrapped_table.rb
@@ -82,6 +82,9 @@ class WrappedTable
     self.sort_index  = opts['SortIndex'] || 0
     self.sort_order  = opts['SortOrder'] || :forward
 
+    self.selected_index = opts['SelectedIndex']
+    self.selected_row_prefix = opts['SelectedRowPrefix'] || '*'
+
     # Default column properties
     self.columns.length.times { |idx|
       self.colprops[idx] = {}
@@ -118,11 +121,22 @@ class WrappedTable
     str << hr_to_s || ''
 
     sort_rows
-    rows.each { |row|
+    selected_row_prefix = self.selected_row_prefix || ''
+
+    rows.each_with_index { |row, idx|
       if (is_hr(row))
         str << hr_to_s
+        next
+      end
+
+      next unless row_visible(row)
+
+      if idx == self.selected_index && selected_row_prefix.length <= indent
+        r = row_to_s(row)
+        r[indent - (selected_row_prefix.length), selected_row_prefix.length] = selected_row_prefix
+        str << r
       else
-        str << row_to_s(row) if row_visible(row)
+        str << row_to_s(row)
       end
     }
 
@@ -325,6 +339,7 @@ class WrappedTable
   attr_accessor :width, :indent, :cellpad # :nodoc:
   attr_accessor :prefix, :postfix # :nodoc:
   attr_accessor :sort_index, :sort_order, :scterm # :nodoc:
+  attr_accessor :selected_index, :selected_row_prefix # :nodoc:
 
 protected
 


### PR DESCRIPTION
A suggestion. Clobbering the indent is a bit janky.

To test this in Metasploit, the following diff must also be applied:

```diff
diff --git a/lib/msf/base/serializer/readable_text.rb b/lib/msf/base/serializer/readable_text.rb
index 8ba4d38012..67bae05150 100644
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -53,6 +53,8 @@ class ReadableText
     tbl = Rex::Text::Table.new(
       'Indent'  => indent.length,
       'Header'  => h,
+      'SelectedIndex' => mod.target_index,
+      'SelectedRowPrefix' => '=> ',
       'Columns' =>
         [
           'Id',
@@ -70,6 +72,8 @@ class ReadableText
     tbl = Rex::Text::Table.new(
       'Indent'  => indent.length,
       'Header'  => h,
+      'SelectedIndex' => mod.target_index,
+      'SelectedRowPrefix' => '=> ',
       'Columns' =>
         [
           'Id',
```

# Existing behavior:

```
msf6 exploit(windows/iis/ms01_023_printer) > set target
target => 1
msf6 exploit(windows/iis/ms01_023_printer) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Windows 2000 SP0-SP1 (Arabic)
   1   Windows 2000 SP0-SP1 (Czech)
   2   Windows 2000 SP0-SP1 (Chinese)
   3   Windows 2000 SP0-SP1 (Dutch)
   4   Windows 2000 SP0-SP1 (English)
   5   Windows 2000 SP0-SP1 (French)
   6   Windows 2000 SP0-SP1 (Finnish)
   7   Windows 2000 SP0-SP1 (German)
   8   Windows 2000 SP0-SP1 (Korean)
   9   Windows 2000 SP0-SP1 (Hungarian)
   10  Windows 2000 SP0-SP1 (Italian)
   11  Windows 2000 SP0-SP1 (Portuguese)
   12  Windows 2000 SP0-SP1 (Spanish)
   13  Windows 2000 SP0-SP1 (Swedish)
   14  Windows 2000 SP0-SP1 (Turkish)
   15  Windows 2000 Pro SP0 (Greek)
   16  Windows 2000 Pro SP1 (Greek)
```

"I'm using target 1... wait which one was that again? Let me list them and play the Spot The Target From The List game"

(The full name of the selected target can be viewed by running `options`, but the other targets aren't shown.)

# New behavior:

```
msf6 exploit(windows/iis/ms01_023_printer) > set target 1
target => 1
msf6 exploit(windows/iis/ms01_023_printer) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Windows 2000 SP0-SP1 (Arabic)
=> 1   Windows 2000 SP0-SP1 (Czech)
   2   Windows 2000 SP0-SP1 (Chinese)
   3   Windows 2000 SP0-SP1 (Dutch)
   4   Windows 2000 SP0-SP1 (English)
   5   Windows 2000 SP0-SP1 (French)
   6   Windows 2000 SP0-SP1 (Finnish)
   7   Windows 2000 SP0-SP1 (German)
   8   Windows 2000 SP0-SP1 (Korean)
   9   Windows 2000 SP0-SP1 (Hungarian)
   10  Windows 2000 SP0-SP1 (Italian)
   11  Windows 2000 SP0-SP1 (Portuguese)
   12  Windows 2000 SP0-SP1 (Spanish)
   13  Windows 2000 SP0-SP1 (Swedish)
   14  Windows 2000 SP0-SP1 (Turkish)
   15  Windows 2000 Pro SP0 (Greek)
   16  Windows 2000 Pro SP1 (Greek)


msf6 exploit(windows/iis/ms01_023_printer) > set target 'Windows 2000 SP0-SP1 (Chinese)'
target => Windows 2000 SP0-SP1 (Chinese)
msf6 exploit(windows/iis/ms01_023_printer) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Windows 2000 SP0-SP1 (Arabic)
   1   Windows 2000 SP0-SP1 (Czech)
=> 2   Windows 2000 SP0-SP1 (Chinese)
   3   Windows 2000 SP0-SP1 (Dutch)
   4   Windows 2000 SP0-SP1 (English)
   5   Windows 2000 SP0-SP1 (French)
   6   Windows 2000 SP0-SP1 (Finnish)
   7   Windows 2000 SP0-SP1 (German)
   8   Windows 2000 SP0-SP1 (Korean)
   9   Windows 2000 SP0-SP1 (Hungarian)
   10  Windows 2000 SP0-SP1 (Italian)
   11  Windows 2000 SP0-SP1 (Portuguese)
   12  Windows 2000 SP0-SP1 (Spanish)
   13  Windows 2000 SP0-SP1 (Swedish)
   14  Windows 2000 SP0-SP1 (Turkish)
   15  Windows 2000 Pro SP0 (Greek)
   16  Windows 2000 Pro SP1 (Greek)


msf6 exploit(windows/iis/ms01_023_printer) > 
```
