### PR TITLE
Run ubuntu 22.04 in test matrix

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,21 @@
 name: Verify
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 on:
   push:
     branches:
@@ -10,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
 
     strategy:
@@ -18,13 +34,21 @@ jobs:
       matrix:
         ruby:
           - 2.7
+          - 3.0
+          - 3.1
+        os:
+          - ubuntu-18.04
+          - ubuntu-22.04
+        exclude:
+          - { os: ubuntu-22.04, ruby: 2.7 }
+          - { os: ubuntu-22.04, ruby: 3.0 }
         test_cmd:
           - bundle exec rspec
 
     env:
       RAILS_ENV: test
 
-    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Relates to https://github.com/rapid7/metasploit-framework/issues/16818

Let's run Ubuntu 22.04 in our test matrix, to catch any OpenSSL v3 regression issues

## Verification

- Code review
- Verify CI passes