### PR TITLE
Adds color support for wrapped tables

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -97,6 +97,11 @@ module Rex
         ( (" " * indent) + prepend + $& + append + 5.chr).gsub(/\n\005/,"\n").gsub(/\005/,"\n")}
     end
 
+
+    # @return [Regexp] Matches a valid color code, i.e. "%blu,%yel,...etc"
+    COLOR_CODES_REGEX = /#{Regexp.union(Rex::Text::Color::SUPPORTED_FORMAT_CODES.compact).source}/
+    private_constant :COLOR_CODES_REGEX
+
     #
     # Function that aims to calculate the display width of the given string.
     # In the future this will be aware of East Asian characters having different display
@@ -104,9 +109,8 @@ module Rex
     #
     # @param [String] str
     # @return [Integer]
-    FORMAT_STRIP_REGEX = /#{Regexp.union(Rex::Text::Color::SUPPORTED_FORMAT_CODES.compact).source}/
     def self.display_width(str)
-      str.gsub(FORMAT_STRIP_REGEX, '').length
+      str.gsub(COLOR_CODES_REGEX, '').length
     end
 
     #

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -97,6 +97,17 @@ module Rex
         ( (" " * indent) + prepend + $& + append + 5.chr).gsub(/\n\005/,"\n").gsub(/\005/,"\n")}
     end
 
+    #
+    # Function that aims to calculate the display width of the given string.
+    # In the future this will be aware of East Asian characters having different display
+    # widths. For now it simply returns the string's length ignoring color codes.
+    #
+    # @param [String] str
+    # @return [Integer]
+    FORMAT_STRIP_REGEX = /#{Regexp.union(Rex::Text::Color::SUPPORTED_FORMAT_CODES.compact).source}/
+    def self.display_width(str)
+      str.gsub(FORMAT_STRIP_REGEX, '').length
+    end
 
     #
     # Convert 16-byte string to a GUID string

--- a/lib/rex/text/color.rb
+++ b/lib/rex/text/color.rb
@@ -10,6 +10,7 @@ module Text
 #
 ###
 module Color
+  SUPPORTED_FORMAT_CODES = %w[%cya %red %grn %blu %yel %whi %mag %blk %dred %dgrn %dblu %dyel %dcya %dwhi %dmag %und %bld %clr %bgblu %bgyel %bggrn %bgmag %bgblk %bgred %bgcyn %bgwhi]
 
   AnsiAttributes =
     {

--- a/lib/rex/text/wrapped_table.rb
+++ b/lib/rex/text/wrapped_table.rb
@@ -406,23 +406,63 @@ protected
   end
 
   #
-  # Takes a hash of color/format tags and converts them to a string
+  # Returns a string of color/formatting codes made up of the previously stored color_state
+  # e.g. if a `%blu` color code spans multiple lines this will return a string of `%blu` to be appended to
+  # the beginning of each row
   #
-  # @param [Hash] color_state
-  # @param [Integer] char_index
-  def color_code_string_for(color_state, char_index)
-    color_str = ""
-
-    unless char_index == 0
-      color_state.each do |_format, value|
-        if value.is_a?(Array)
-          color_str += value.join
-        else
-          color_str += value
-        end
+  # @param [Hash<String, String>] color_state tracks current color/formatting codes within table row
+  # @returns [String] Color code string such as `%blu%grn'
+  def color_code_string_for(color_state)
+    result = ''.dup
+    color_state.each do |_format, value|
+      if value.is_a?(Array)
+        result << value.uniq.join
+      else
+        result << value
       end
     end
-    color_str
+    result
+  end
+
+  # @returns [Hash<String, String>] The supported color codes from {Rex::Text::Color} grouped into sections
+  def color_code_groups
+    return @color_code_groups if @color_code_groups
+
+    @color_code_groups = {
+      foreground: %w[
+        %cya %red %grn %blu %yel %whi %mag %blk
+        %dred %dgrn %dblu %dyel %dcya %dwhi %dmag
+      ],
+      background: %w[
+        %bgblu %bgyel %bggrn %bgmag %bgblk %bgred %bgcyn %bgwhi
+      ],
+      decoration: %w[
+        %und %bld
+      ],
+      clear: %w[
+        %clr
+      ]
+    }
+
+    # Developer exception raised to ensure all color codes are accounted for. Verified via tests.
+    missing_color_codes = (Rex::Text::Color::SUPPORTED_FORMAT_CODES - @color_code_groups.values.flatten)
+    raise "Unsupported color codes #{missing_color_codes.join(', ')}" if missing_color_codes.any?
+
+    @color_code_groups
+  end
+
+  # Find the preceding color type and value of a given string
+  # @param [String] string A string such as '%bgyel etc'
+  # @returns [Array,nil] A tuple with the color type and value, or nil
+  def find_color_type_and_value(string)
+    color_code_groups.each do |color_type, color_values|
+      color_value = color_values.find { |color_value| string.start_with?(color_value) }
+      if color_value
+        return [color_type, color_value]
+      end
+    end
+
+    nil
   end
 
   #
@@ -432,13 +472,12 @@ protected
   # e.g. if a formatting "%blu" spans across multiple lines it needs to be added to the beginning off every following
   # line, and each line will have a "%clr" added to the end of each row
   #
-  # @param [Array] values
+  # @param [Array<String>] values
   # @param [Integer] optimal_widths
   def chunk_values(values, optimal_widths)
-    color_state = {}
-
     # First split long strings into an array of chunks, where each chunk size is the calculated column width
     values_as_chunks = values.each_with_index.map do |value, idx|
+      color_state = {}
       column_width = optimal_widths[idx]
       chunks = []
       current_chunk = nil
@@ -447,58 +486,49 @@ protected
 
       # Check if any color code(s) from previous the string need appended
       while char_index < chars.length do
-        if current_chunk.nil?
-          previous_color_codes = color_code_string_for(color_state, char_index)
-          current_chunk = previous_color_codes
+        # If a new chunk has started, start the chunk with any previous color codes
+        if current_chunk.nil? && color_state.any?
+          current_chunk = color_code_string_for(color_state)
         end
+        current_chunk ||= ''.dup
 
-        # Matches color codes and adds them to the color_state hash, uses color/formats purpose as key
-        # e.g. {:foreground=>"%blu"}
-        if chars[char_index] == '%'
-          if value[char_index..(char_index + 3)] == '%und' ||  value[char_index..(char_index + 3)] == '%bld'
-            color_state[:format] = []
-            color_state[:format] << [value[char_index..(char_index + 3)]]
-            current_chunk << value[char_index..(char_index + 3)]
-            char_index += 3
-          elsif value[char_index..(char_index + 3)] == '%clr'
-            color_state.clear
-            current_chunk << '%clr'
-            char_index += 3
-          elsif Rex::Text::Color::SUPPORTED_FORMAT_CODES.include?(value[char_index..(char_index + 5)])
-            color_state[:background] = value[char_index..(char_index + 5)] unless value[char_index..(char_index + 5)].end_with?('%clr')
-            current_chunk << value[char_index..(char_index + 5)]
-            char_index += 5
-          elsif Rex::Text::Color::SUPPORTED_FORMAT_CODES.include?(value[char_index..(char_index + 3)])
-            color_state[:foreground] = value[char_index..(char_index + 3)]
-            current_chunk << value[char_index..(char_index + 3)]
-            char_index += 3
-          end
-        else
+        # Check if the remaining chars start with a color code such as %blu
+        color_type_and_value = chars[char_index] == '%' ? find_color_type_and_value(chars[char_index..].join) : nil
+        if color_type_and_value.nil?
           current_chunk << chars[char_index]
+          char_index += 1
+        else
+          color_type, color_code = color_type_and_value
+
+          if color_type == :clear
+            color_state.clear
+          elsif color_type == :decoration
+            # Multiple decorations can be enabled
+            color_state[:decoration] ||= []
+            color_state[:decoration] << color_code
+          else
+            # There can only be one foreground or background color
+            color_state[color_type] = color_code
+          end
+
+          current_chunk << color_code
+          char_index += color_code.length
         end
 
-        # display_width will calculate the string's length ignoring color codes
-        if display_width(current_chunk) == column_width
-          unless color_state.empty?
-            current_chunk.insert(-1, '%clr') unless current_chunk.end_with?('%clr')
+        # If we've reached the final character of the string, or need to word wrap
+        # it's time to push the current chunk, and start a new row. Also discard
+        # any values that are purely colors and have no display_width
+        is_final_character = char_index >= chars.length
+        display_width = display_width(current_chunk)
+        if (is_final_character && display_width != 0) || display_width == column_width
+          if color_state.any? && !current_chunk.end_with?('%clr')
+            current_chunk << '%clr'
           end
           chunks.push(current_chunk)
           current_chunk = nil
         end
-        char_index += 1
       end
 
-      if current_chunk != nil
-        unless color_state.empty?
-          current_chunk.insert(-1, '%clr') unless current_chunk.end_with?('%clr')
-        end
-
-        unless display_width(current_chunk) == 0
-          chunks.push(current_chunk)
-        end
-      end
-
-      color_state.clear
       chunks
     end
 
@@ -609,7 +639,7 @@ protected
   end
 
   def style_table_field(str, idx)
-    str_cp = str.clone
+    str_cp = str.dup
 
     colprops[idx]['Stylers'].each do |s|
       str_cp = s.style(str_cp)

--- a/spec/rex/text/table_spec.rb
+++ b/spec/rex/text/table_spec.rb
@@ -61,8 +61,73 @@ describe Rex::Text::Table do
 
       it "ignores the user preference when set to false" do
         expect(described_class.wrap_table?(disable_wrapped_table_options)).to be false
-      end      
+      end
     end
+  end
+
+  it 'should return a blank table as no search terms were matched' do
+    col_1_field = "A" * 5
+    col_2_field = "B" * 50
+    col_3_field = "C" * 15
+
+    options = {
+      'Header' => 'Header',
+      'SearchTerm' => 'jim|bob',
+      'Columns' => [
+        'Column 1',
+        'Column 2',
+        'Column 3'
+      ]
+    }
+
+    tbl = Rex::Text::Table.new(options)
+
+    tbl << [
+      col_1_field,
+      col_2_field,
+      col_3_field
+    ]
+
+    expect(tbl.to_s).to eql <<~TABLE
+      Header
+      ======
+
+      Column 1  Column 2                                            Column 3
+      --------  --------                                            --------
+    TABLE
+  end
+
+  it 'should return the row as the row contains a match for the search term' do
+    col_1_field = "jim"
+    col_2_field = "B" * 50
+    col_3_field = "C" * 15
+
+    options = {
+      'Header' => 'Header',
+      'SearchTerm' => 'jim|bob',
+      'Columns' => [
+        'Column 1',
+        'Column 2',
+        'Column 3'
+      ]
+    }
+
+    tbl = Rex::Text::Table.new(options)
+
+    tbl << [
+      col_1_field,
+      col_2_field,
+      col_3_field
+    ]
+
+    expect(tbl.to_s).to eql <<~TABLE
+      Header
+      ======
+
+      Column 1  Column 2                                            Column 3
+      --------  --------                                            --------
+      jim       BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB  CCCCCCCCCCCCCCC
+    TABLE
   end
 
   it 'should space columns correctly' do
@@ -72,7 +137,6 @@ describe Rex::Text::Table do
 
     options = {
       'Header' => 'Header',
-      'SearchTerm' => ['jim', 'bob'],
       'Columns' => [
         'Column 1',
         'Column 2',
@@ -105,7 +169,6 @@ describe Rex::Text::Table do
 
     options = {
       'Header' => 'Header',
-      'SearchTerm' => ['jim', 'bob'],
       'Columns' => [
         'Column 1',
         'Column 2',
@@ -144,7 +207,6 @@ describe Rex::Text::Table do
 
     options = {
       'Header' => 'Header',
-      'SearchTerm' => ['jim', 'bob'],
       'Columns' => [
         'Column 1',
         'Column 2',

--- a/spec/rex/text/wrapped_table_spec.rb
+++ b/spec/rex/text/wrapped_table_spec.rb
@@ -661,6 +661,38 @@ describe Rex::Text::Table do
         expect(tbl.to_s.lines).to all(have_maximum_display_width(80))
       end
 
+      it "safely wordwraps cells when an % symbol that is not associated with a color/format codes is present" do
+
+        options = {
+          'Header' => 'Header',
+          'Indent' => 0,
+          'Width' => 80,
+          'Columns' => [
+            'Blue Column',
+            'Red Column'
+          ]
+        }
+
+        tbl = Rex::Text::Table.new(options)
+        tbl << [
+          "%#{'A' * 49}%#{'A' * 49}",
+          "%#{'A' * 49}%#{'A' * 49}",
+        ]
+
+        expect(tbl).to match_table <<~TABLE
+          Header
+          ======
+
+          Blue Column                             Red Column
+          -----------                             ----------
+          %AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  %AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAA%AAAAAAAAAAAAAAAAAAAAAAAAA  AAAAAAAAAAAA%AAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAA                AAAAAAAAAAAAAAAAAAAAAAAA
+        TABLE
+
+        expect(tbl.to_s.lines).to all(have_maximum_display_width(80))
+      end
+
       it "safely wordwraps cells that have a single color/format across multiple lines" do
 
         options = {
@@ -757,7 +789,7 @@ describe Rex::Text::Table do
         expect(tbl.to_s.lines).to all(have_maximum_display_width(80))
       end
 
-      it "verify that no formatting is added when not required" do
+      it "safely wordwraps cells when there is no color/formatting codes present" do
 
         options = {
           'Header' => 'Header',
@@ -809,7 +841,7 @@ describe Rex::Text::Table do
         expect(tbl).to match_table <<~TABLE
           Header
           ======
-          
+
           Blue Column                             Red Column
           -----------                             ----------
           %bluAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr  %redAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr
@@ -841,7 +873,7 @@ describe Rex::Text::Table do
         expect(tbl).to match_table <<~TABLE
           Header
           ======
-          
+
           Blue Column                             Red Column
           -----------                             ----------
           %bluAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr  %redAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr
@@ -851,6 +883,36 @@ describe Rex::Text::Table do
         expect(tbl.to_s.lines).to all(have_maximum_display_width(80))
       end
 
+      it 'supports dark color codes' do
+
+        options = {
+          'Header' => 'Header',
+          'Indent' => 0,
+          'Width' => 80,
+          'Columns' => [
+            'Blue Column',
+            'Red Column'
+          ]
+        }
+
+        tbl = Rex::Text::Table.new(options)
+        tbl << [
+          "%dyel#{'A' * 40}%clr",
+          "%dcya#{'A' * 40}%clr",
+        ]
+
+        expect(tbl).to match_table <<~TABLE
+          Header
+          ======
+
+          Blue Column                             Red Column
+          -----------                             ----------
+          %dyelAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr  %dcyaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr
+          %dyelAA%clr                                      %dcyaAA%clr
+        TABLE
+
+        expect(tbl.to_s.lines).to all(have_maximum_display_width(80))
+      end
 
       it "verify that formatting aligns correctly" do
 
@@ -880,8 +942,8 @@ describe Rex::Text::Table do
           n
           -  -
           %bgyel%blu%bld%undA%clr  %bgyel%blu%bld%undA%clr
-          %bgyel%blu%undA%clr  %bgyel%blu%undA%clr
-          %bgyel%blu%undA%clr  %bgyel%blu%undA%clr
+          %bgyel%blu%bld%undA%clr  %bgyel%blu%bld%undA%clr
+          %bgyel%blu%bld%undA%clr  %bgyel%blu%bld%undA%clr
         TABLE
 
         expect(tbl.to_s.lines).to all(have_maximum_display_width(7))

--- a/spec/rex/text_spec.rb
+++ b/spec/rex/text_spec.rb
@@ -95,6 +95,49 @@ RSpec.describe Rex::Text do
       end
     end
 
+    describe ".display_width" do
+      it "verify that display width calculates correct display width when no format codes are present" do
+        str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        expect(Rex::Text.display_width(str)).to eq(100)
+      end
+
+      it "verify that display width calculates correct display width when format codes are present" do
+        str = "%bluAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr"
+        expect(Rex::Text.display_width(str)).to eq(100)
+      end
+
+      it "verify that display width calculates correct display width when format codes are chained together" do
+        str = "%bgyel%blu%bld%grn%undAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr"
+        expect(Rex::Text.display_width(str)).to eq(100)
+      end
+
+      it "verify that display width calculates correct display width when format codes are chained together with multiple seperate formatting instances" do
+        str = "%bgyel%blu%bld%undhello%clr %bgyel%blu%bld%undworld%clr"
+        expect(Rex::Text.display_width(str)).to eq(11)
+      end
+
+      it "verify that display width calculates correct display width when format codes are chained together with multiple seperate formatting instances" do
+        str = "%dgrnhello world%clr"
+        expect(Rex::Text.display_width(str)).to eq(11)
+      end
+
+      it "verify that display width calculates correct display width when emojis with modifiers are passed" do
+        # https://stackoverflow.com/questions/42778709/the-longest-character-in-utf-8
+        str = "🤦🏻‍♂️".force_encoding('UTF-8')
+
+        # For future travelers, this could technically be a width of 1, but is dependant on how the console renders it
+        expect(Rex::Text.display_width(str)).to eq(5)
+      end
+
+      it "verify that display width calculates correct display width when emojis with modifiers are passed" do
+        # https://stackoverflow.com/questions/42778709/the-longest-character-in-utf-8
+        str = "🤦🏻‍♂️".force_encoding('ASCII-8BIT')
+
+        # For future travelers, this could technically be a width of 1, but is dependant on how the console renders it
+        expect(Rex::Text.display_width(str)).to eq(17)
+      end
+    end
+
     context ".gzip" do
       it "should return a properly formatted gzip file" do
         str = described_class.gzip("hi mom")

--- a/spec/rex/text_spec.rb
+++ b/spec/rex/text_spec.rb
@@ -96,45 +96,45 @@ RSpec.describe Rex::Text do
     end
 
     describe ".display_width" do
-      it "verify that display width calculates correct display width when no format codes are present" do
+      it "verifies that display width calculates correct display width when no format codes are present" do
         str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        expect(Rex::Text.display_width(str)).to eq(100)
+        expect(described_class.display_width(str)).to eq(100)
       end
 
-      it "verify that display width calculates correct display width when format codes are present" do
+      it "verifies that display width calculates correct display width when format codes are present" do
         str = "%bluAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr"
-        expect(Rex::Text.display_width(str)).to eq(100)
+        expect(described_class.display_width(str)).to eq(100)
       end
 
-      it "verify that display width calculates correct display width when format codes are chained together" do
+      it "verifies that display width calculates correct display width when format codes are chained together" do
         str = "%bgyel%blu%bld%grn%undAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%clr"
-        expect(Rex::Text.display_width(str)).to eq(100)
+        expect(described_class.display_width(str)).to eq(100)
       end
 
-      it "verify that display width calculates correct display width when format codes are chained together with multiple seperate formatting instances" do
+      it "verifies that display width calculates correct display width when format codes are chained together with multiple seperate formatting instances" do
         str = "%bgyel%blu%bld%undhello%clr %bgyel%blu%bld%undworld%clr"
-        expect(Rex::Text.display_width(str)).to eq(11)
+        expect(described_class.display_width(str)).to eq(11)
       end
 
-      it "verify that display width calculates correct display width when format codes are chained together with multiple seperate formatting instances" do
+      it "verifies that display width calculates correct display width when format codes are chained together with multiple seperate formatting instances" do
         str = "%dgrnhello world%clr"
-        expect(Rex::Text.display_width(str)).to eq(11)
+        expect(described_class.display_width(str)).to eq(11)
       end
 
-      it "verify that display width calculates correct display width when emojis with modifiers are passed" do
+      it "verifies that display width calculates correct display width when emojis with modifiers are passed" do
         # https://stackoverflow.com/questions/42778709/the-longest-character-in-utf-8
         str = "🤦🏻‍♂️".force_encoding('UTF-8')
 
         # For future travelers, this could technically be a width of 1, but is dependant on how the console renders it
-        expect(Rex::Text.display_width(str)).to eq(5)
+        expect(described_class.display_width(str)).to eq(5)
       end
 
-      it "verify that display width calculates correct display width when emojis with modifiers are passed" do
+      it "verifies that display width calculates correct display width when emojis with modifiers are passed" do
         # https://stackoverflow.com/questions/42778709/the-longest-character-in-utf-8
         str = "🤦🏻‍♂️".force_encoding('ASCII-8BIT')
 
         # For future travelers, this could technically be a width of 1, but is dependant on how the console renders it
-        expect(Rex::Text.display_width(str)).to eq(17)
+        expect(described_class.display_width(str)).to eq(17)
       end
     end
 

--- a/spec/support/matchers/have_maximum_display_width.rb
+++ b/spec/support/matchers/have_maximum_display_width.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :have_maximum_display_width do |expected|
+  match do |actual|
+    Rex::Text.display_width(actual) <= expected
+  end
+
+  failure_message do |actual|
+    "expected '#{actual}' to have a length than or equal to #{expected}, instead got #{actual.length}"
+  end
+end


### PR DESCRIPTION
This PR adds color support for wrapped tables, as well as tests to cover as many edge cases as possible.

## Before
![image](https://user-images.githubusercontent.com/69522014/185961742-6959fa8b-a40d-4ce8-a9d5-f3786530d896.png)

## After
![image](https://user-images.githubusercontent.com/69522014/185959613-bfa8d235-b5b7-43cf-bd03-fdeb8a28676d.png)

## Prerequisites
Checkout this branch and add the `rex-text` gem into your Metasploit `gemfile`.
```Ruby
gemspec name: 'metasploit-framework'
gem "rex-text", path: "../rex-text"
```
Set [WordWrap](https://github.com/rapid7/metasploit-framework/blob/5d935bdd0a25ff20d01f67e3c822685fc1c79aee/lib/msf/ui/console/command_dispatcher/modules.rb#L16) to `true` within `lib/msf/ui/console/command_dispatcher/modules.rb`

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Verify `search` command highlight expected result(s)
- [ ] Adjust terminal window size
- [ ] Verify again that `search` command highlight expected result(s)
- [ ]  Verify table are being wrapped as expected