### PR TITLE
Adds support to remove column decoration and headers

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -110,6 +110,8 @@ module Rex
     # @param [String] str
     # @return [Integer]
     def self.display_width(str)
+      return 0 if str.nil?
+
       str.gsub(COLOR_CODES_REGEX, '').length
     end
 


### PR DESCRIPTION
## This PR needs to be test as a pair with this Metasploit Framework [PR](https://github.com/rapid7/metasploit-framework/pull/16946)

The commit for this PR are actually changes @adfoster-r7 made. We didn't want to open a new PR and loose the paper trail here with comments/recommendations, so we just translated those changes to this PR. Thanks Alan 🎉 


This PR adds support to remove column headers and column decoration from wrapped tables via Stylers.

This is to support a Metasploit Framework [PR](https://github.com/rapid7/metasploit-framework/pull/16946) to add row indicators to `show targets` command. 

## Example
Users can now pass specific columns Stylers.
```Ruby
      'ColProps' => {
        'IsTarget' => {
          'Stylers' => [Msf::Ui::Console::TablePrint::RowIndicatorStyler.new],
          'ColumnStylers' => [Msf::Ui::Console::TablePrint::OmitColumnHeader.new],
          'Width' => 2
        }
      }
```

### Before
![image](https://user-images.githubusercontent.com/69522014/189697972-444108c9-231c-483e-91bf-d4449003f436.png)

When it was being calculated it was using the column header length from before they Styler had be ran against it.


### After 
![image](https://user-images.githubusercontent.com/69522014/189697577-9325a98a-2763-46d1-b915-938437d1c8a6.png)

Now it will calculate width when it's called via wrapped tables [`to_s`](https://github.com/rapid7/rex-text/blob/71338854cfbc04adf6be0543f7fa4bcf646a2257/lib/rex/text/wrapped_table.rb#L117), this means it will only be styled when being output to console but maintain the more readable data when `to_csv` is called:

![image](https://user-images.githubusercontent.com/69522014/189699247-3aab262f-4887-47f2-9660-3ac0a449d24d.png)

## Prerequisites
Checkout this branch and add the `rex-text` gem into your Metasploit `gemfile`.
```Ruby
gemspec name: 'metasploit-framework'
gem "rex-text", path: "../rex-text"
```

## Verification

Unfortunately won't be able to test fully without having changes from both this PR and a Metasploit Framework [feature](https://github.com/rapid7/metasploit-framework/pull/16946).

Complete prerequisites steps here and then complete verification steps in the Metasploit Framework [PR](https://github.com/rapid7/metasploit-framework/pull/16946).