### PR TITLE
added golang support for output.

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -41,16 +41,23 @@ module Rex
     #
     # Converts to a golang style array of bytes
     #
-    def self.to_golang(str,name = "buf")
-      data = to_num(str).gsub(/\s+/, "").split(",") # Might be a better way of doing this....
-      return name + " := []byte{%s}" % [data.join(", ")] # Note, I've tried setting the size of the buffer manually to be more efficent it go, but better results are seen when using an undelcared array size.
+    def self.to_golang(str, wrap = DefaultWrap, name = "buf")
+      ret = " #{name} :=  []byte{"
+      i = -1;
+      while (i += 1) < str.length
+        ret << "\n" if i%(wrap/4) == 0
+        ret << "0x" << str[i].unpack("H*")[0] << ", "
+      end
+      ret = ret[0..ret.length-3] #cut off last comma
+      ret << " }\n"
+
     end
     
     #
     # Creates a golang style comment
     #
     def self.to_golang_comment(str,  wrap = DefaultWrap)
-      return "/*" + wordwrap(str, 0, wrap, '', ' * ') + "*/\n" 
+      return "/*\n" + wordwrap(str, 0, wrap, '', '') + "*/\n" 
     end
 
 

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -39,11 +39,29 @@ module Rex
     end
 
     #
+    # Converts to a golang style array of bytes
+    #
+    def self.to_golang(str,name = "buf")
+      data = to_num(str).gsub(/\s+/, "").split(",") # Might be a better way of doing this....
+      return name + " := []byte{%s}" % [data.join(", ")] # Note, I've tried setting the size of the buffer manually to be more efficent it go, but better results are seen when using an undelcared array size.
+    end
+    
+    #
+    # Creates a golang style comment
+    #
+    def self.to_golang_comment(str,  wrap = DefaultWrap)
+      return "/*" + wordwrap(str, 0, wrap, '', ' * ') + "*/\n" 
+    end
+
+
+    #
     # Creates a c-style comment
     #
     def self.to_c_comment(str, wrap = DefaultWrap)
       return "/*\n" + wordwrap(str, 0, wrap, '', ' * ') + " */\n"
     end
+
+    
 
     #
     # Creates a javascript-style comment


### PR DESCRIPTION
Added `self.to_golang` and `self.to_golang_comment` for golang buffer arary output format.

There is an option when declaring a golang array to define the array size `buf := [3]byte{0x00,0x00,0x00}`, but I found that letting golang dynamically define the array size is a better approach.

The aim is to allow golang buffer output when generating the msfvenom payload using `msfvenom -p windows/x64/exec CMD=calc.exe -f go` 

Returning this format:
```
/*
windows/exec - 193 bytes
https://metasploit.com/
VERBOSE=false, PrependMigrate=false, EXITFUNC=process, CMD=calc.exe
*/
buf := []byte{0xfc, 0xe8, 0x82, 0x00, 0x00, 0x00, 0x60, 0x89, 0xe5, 0x31, 0xc0, 0x64, 0x8b, 0x50, 0x30, 0x8b, 0x52, 0x0c, 0x8b, 0x52, 0x14, 0x8b, 0x72, 0x28, 0x0f, 0xb7, 0x4a, 0x26, 0x31, 0xff, 0xac, 0x3c, 0x61, 0x7c, 0x02, 0x2c, 0x20, 0xc1, 0xcf, 0x0d, 0x01, 0xc7, 0xe2, 0xf2, 0x52, 0x57, 0x8b, 0x52, 0x10, 0x8b, 0x4a, 0x3c, 0x8b, 0x4c, 0x11, 0x78, 0xe3, 0x48, 0x01, 0xd1, 0x51, 0x8b, 0x59, 0x20, 0x01, 0xd3, 0x8b, 0x49, 0x18, 0xe3, 0x3a, 0x49, 0x8b, 0x34, 0x8b, 0x01, 0xd6, 0x31, 0xff, 0xac, 0xc1, 0xcf, 0x0d, 0x01, 0xc7, 0x38, 0xe0, 0x75, 0xf6, 0x03, 0x7d, 0xf8, 0x3b, 0x7d, 0x24, 0x75, 0xe4, 0x58, 0x8b, 0x58, 0x24, 0x01, 0xd3, 0x66, 0x8b, 0x0c, 0x4b, 0x8b, 0x58, 0x1c, 0x01, 0xd3, 0x8b, 0x04, 0x8b, 0x01, 0xd0, 0x89, 0x44, 0x24, 0x24, 0x5b, 0x5b, 0x61, 0x59, 0x5a, 0x51, 0xff, 0xe0, 0x5f, 0x5f, 0x5a, 0x8b, 0x12, 0xeb, 0x8d, 0x5d, 0x6a, 0x01, 0x8d, 0x85, 0xb2, 0x00, 0x00, 0x00, 0x50, 0x68, 0x31, 0x8b, 0x6f, 0x87, 0xff, 0xd5, 0xbb, 0xf0, 0xb5, 0xa2, 0x56, 0x68, 0xa6, 0x95, 0xbd, 0x9d, 0xff, 0xd5, 0x3c, 0x06, 0x7c, 0x0a, 0x80, 0xfb, 0xe0, 0x75, 0x05, 0xbb, 0x47, 0x13, 0x72, 0x6f, 0x6a, 0x00, 0x53, 0xff, 0xd5, 0x63, 0x61, 0x6c, 0x63, 0x2e, 0x65, 0x78, 0x65, 0x00}
```

Right now, there is no wrapper option, but I will investigate adding this. 