### PR TITLE
Fix Language Wrapping

### DIFF
--- a/lib/rex/text/hex.rb
+++ b/lib/rex/text/hex.rb
@@ -127,6 +127,11 @@ module Rex
     # Converts a string to a hex version with wrapping support
     #
     def self.hexify(str, col = DefaultWrap, line_start = '', line_end = '', buf_start = '', buf_end = '')
+      if col < line_start.length + 4 + line_end.length
+        # raise an exception
+        raise ArgumentError.new('insufficient column width')
+      end
+
       ret = buf_start.dup
       ret << line_start if ret.end_with?("\n")
       str.each_char do |char|

--- a/lib/rex/text/hex.rb
+++ b/lib/rex/text/hex.rb
@@ -127,21 +127,22 @@ module Rex
     # Converts a string to a hex version with wrapping support
     #
     def self.hexify(str, col = DefaultWrap, line_start = '', line_end = '', buf_start = '', buf_end = '')
-      output	 = buf_start
-      cur	 = 0
-      count	 = 0
+      output = buf_start
+      cur = 0
+      count = 0
       new_line = true
 
       # Go through each byte in the string
       str.each_byte { |byte|
-        count  += 1
-        append	= ''
+        count += 1
+        append = ''
 
         # If this is a new line, prepend with the
         # line start text
         if (new_line == true)
-          append	 << line_start
-          new_line  = false
+          append << line_start
+          cur += line_start.length
+          new_line = false
         end
 
         # Append the hexified version of the byte
@@ -150,9 +151,9 @@ module Rex
 
         # If we're about to hit the column or have gone past it,
         # time to finish up this line
-        if ((cur + line_end.length >= col) or (cur + buf_end.length  >= col))
-          new_line  = true
-          cur	  = 0
+        if ((line_start.length + cur + line_end.length >= col) or (cur + buf_end.length  >= col))
+          new_line = true
+          cur = 0
 
           # If this is the last byte, use the buf_end instead of
           # line_end

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -34,7 +34,7 @@ module Rex
         ret << "\n" if ret.split("\n").last.length + 5 > wrap
         ret << "0x" << char.unpack('H*')[0] << ","
       end
-      ret = ret[0..ret.length - 2] # cut off last comma
+      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
       ret << "\n" if ret.split("\n").last.length + 2 > wrap
       ret << "};\n"
     end
@@ -49,7 +49,7 @@ module Rex
         ret << "\n" if ret.split("\n").last.length + 5 > wrap
         ret << "0x" << char.unpack('H*')[0] << ","
       end
-      ret = ret[0..ret.length - 2] # cut off last comma
+      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
       ret << "\n" if ret.split("\n").last.length + 2 > wrap
       ret << "};\n"
     end

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -29,13 +29,14 @@ module Rex
 
     def self.to_csharp(str, wrap = DefaultWrap, name = "buf")
       ret = "byte[] #{name} = new byte[#{str.length}] {"
-      i = -1;
-      while (i += 1) < str.length
-        ret << "\n" if i%(wrap/4) == 0
-        ret << "0x" << str[i].unpack("H*")[0] << ","
+      str.each_char do |char|
+        # "0x##,".length is 5, check if we're going over the wrap boundary
+        ret << "\n" if ret.split("\n").last.length + 5 > wrap
+        ret << "0x" << char.unpack('H*')[0] << ","
       end
-      ret = ret[0..ret.length-2] #cut off last comma
-      ret << " };\n"
+      ret = ret[0..ret.length - 2] # cut off last comma
+      ret << "\n" if ret.split("\n").last.length + 2 > wrap
+      ret << "};\n"
     end
 
     #
@@ -43,21 +44,21 @@ module Rex
     #
     def self.to_golang(str, wrap = DefaultWrap, name = "buf")
       ret = "#{name} :=  []byte{"
-      i = -1;
-      while (i += 1) < str.length
-        ret << "\n" if i%(wrap/4) == 0
-        ret << "0x" << str[i].unpack("H*")[0] << ", "
+      str.each_char do |char|
+        # "0x##,".length is 5, check if we're going over the wrap boundary
+        ret << "\n" if ret.split("\n").last.length + 5 > wrap
+        ret << "0x" << char.unpack('H*')[0] << ","
       end
-      ret = ret[0..ret.length-3] #cut off last comma
-      ret << " }\n"
-
+      ret = ret[0..ret.length - 2] # cut off last comma
+      ret << "\n" if ret.split("\n").last.length + 2 > wrap
+      ret << "};\n"
     end
-    
+
     #
     # Creates a golang style comment
     #
     def self.to_golang_comment(str,  wrap = DefaultWrap)
-      return "/*\n" + wordwrap(str, 0, wrap, '', '') + "*/\n" 
+      return "/*\n" + wordwrap(str, 0, wrap, '', '') + "*/\n"
     end
 
     #
@@ -180,7 +181,6 @@ module Rex
     def self.to_psh_comment(str, wrap = DefaultWrap)
       return wordwrap(str, 0, wrap, '', '# ')
     end
-
 
   end
 end

--- a/spec/rex/text/hex_spec.rb
+++ b/spec/rex/text/hex_spec.rb
@@ -1,0 +1,19 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Text do
+  context "Class Hex methods" do
+    context ".hexify" do
+      let(:wrap) { 60 }
+      it 'should wrap at the specified columns' do
+        lines = described_class.hexify("A" * 100, wrap).split("\n")
+        expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
+      end
+
+      it 'should wrap at the specified columns when a line start and end are specified' do
+        lines = described_class.hexify("A" * 100, wrap, '"', '"').split("\n")
+        expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/rex/text/hex_spec.rb
+++ b/spec/rex/text/hex_spec.rb
@@ -2,22 +2,20 @@
 require 'spec_helper'
 
 RSpec.describe Rex::Text do
-  context "Class Hex methods" do
-    context ".hexify" do
-      let(:wrap) { 60 }
-      it 'should wrap at the specified columns' do
-        lines = described_class.hexify("A" * 100, wrap).split("\n")
-        expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
-      end
+  describe ".hexify" do
+    let(:wrap) { 60 }
+    it 'should wrap at the specified columns' do
+      lines = described_class.hexify("A" * 100, wrap).split("\n")
+      expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
+    end
 
-      it 'should wrap at the specified columns when a line start and end are specified' do
-        lines = described_class.hexify("A" * 100, wrap, '"', '"').split("\n")
-        expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
-      end
+    it 'should wrap at the specified columns when a line start and end are specified' do
+      lines = described_class.hexify("A" * 100, wrap, '"', '"').split("\n")
+      expect(lines).to all(have_maximum_width(wrap))
+    end
 
-      it 'should convert the buffer to hex' do
-        expect(described_class.hexify(Random.bytes(8))).to match(/(\\x[a-fA-F0-9]{2}){8}/)
-      end
+    it 'should convert the buffer to hex' do
+      expect(described_class.hexify(Random.bytes(8))).to match(/(\\x[a-fA-F0-9]{2}){8}/)
     end
   end
 end

--- a/spec/rex/text/hex_spec.rb
+++ b/spec/rex/text/hex_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Rex::Text do
         lines = described_class.hexify("A" * 100, wrap, '"', '"').split("\n")
         expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
       end
+
+      it 'should convert the buffer to hex' do
+        expect(described_class.hexify(Random.bytes(8))).to match(/(\\x[a-fA-F0-9]{2}){8}/)
+      end
     end
   end
 end

--- a/spec/rex/text/lang_spec.rb
+++ b/spec/rex/text/lang_spec.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Text do
+  context "Class Language methods" do
+
+    LANGUAGES = %w[ bash c csharp golang perl python ruby ]
+
+    context "to language methods should wrap at the specified columns" do
+      LANGUAGES.each do |lang|
+        context ".to_#{lang}" do
+          it "should raise on non-convertable characters" do
+            wrap = 60
+            lines = described_class.send("to_#{lang}", "A" * 100, wrap).split("\n")
+            expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rex/text/lang_spec.rb
+++ b/spec/rex/text/lang_spec.rb
@@ -2,18 +2,16 @@
 require 'spec_helper'
 
 RSpec.describe Rex::Text do
-  context "Class Language methods" do
 
-    LANGUAGES = %w[ bash c csharp golang perl python ruby ]
+  LANGUAGES = %w[ bash c csharp golang perl python ruby ]
 
-    context "to language methods should wrap at the specified columns" do
-      LANGUAGES.each do |lang|
-        context ".to_#{lang}" do
-          it "should raise on non-convertable characters" do
-            wrap = 60
-            lines = described_class.send("to_#{lang}", "A" * 100, wrap).split("\n")
-            expect(lines.any? { |line| line.rstrip.length > wrap }).to be_falsey
-          end
+  context "to language methods should wrap at the specified columns" do
+    LANGUAGES.each do |lang|
+      describe ".to_#{lang}" do
+        it "should raise on non-convertable characters" do
+          wrap = 60
+          lines = described_class.send("to_#{lang}", "A" * 100, wrap).split("\n")
+          expect(lines).to all(have_maximum_width(wrap))
         end
       end
     end


### PR DESCRIPTION
I suggest reviewing the code without whitespace changes. I converted some tab characters to spaces.

This fixes #51. The `#hexify` and `#to_$lang` methods were not correctly wrapping at the specified number of columns. This also adds a unit test to show that the wrapping is working now, and to ensure that it continues to work as expected in the future.

## Before

```
[10] pry(main)> puts Rex::Text.to_ruby("A"*50, 60)
buf = 
"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" +
"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" +
"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" +
"\x41\x41\x41\x41\x41\x41\x41\x41"
=> nil
[11] pry(main)> puts Rex::Text.to_python("A"*50, 60)
buf =  b""
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
=> nil
[12] pry(main)> puts Rex::Text.to_csharp("A"*50, 60)
byte[] buf = new byte[50] {
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41 };
=> nil
[13] pry(main)> puts Rex::Text.to_golang("A"*50, 60)
 buf :=  []byte{
0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 
0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 
0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 
0x41, 0x41, 0x41, 0x41, 0x41 }
=> nil
[14] pry(main)> 
```

## After 

```
[1] pry(main)> require 'rex/text'
=> true
[2] pry(main)> puts Rex::Text.to_ruby("A"*50, 60)
buf = 
"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" +
"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" +
"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" +
"\x41\x41\x41\x41\x41\x41\x41\x41"
=> nil
[3] pry(main)> puts Rex::Text.to_python("A"*50, 60)
buf =  b""
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41"
buf += b"\x41\x41"
=> nil
[4] pry(main)> puts Rex::Text.to_csharp("A"*50, 60)
byte[] buf = new byte[50] {0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41};
=> nil
[5] pry(main)> puts Rex::Text.to_golang("A"*50, 60)
buf :=  []byte{0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,0x41,
0x41,0x41,0x41,0x41,0x41};
=> nil
[6] pry(main)>
```