### PR TITLE
Extract matchers to files

### DIFF
--- a/spec/rex/text/wrapped_table_spec.rb
+++ b/spec/rex/text/wrapped_table_spec.rb
@@ -3,43 +3,6 @@
 require 'spec_helper'
 require 'rex/text/wrapped_table'
 
-RSpec::Matchers.define :have_maximum_width do |expected|
-  match do |actual|
-    actual.length <= expected
-  end
-  failure_message do |actual|
-    "expected '#{actual}' to have a length than or equal to #{expected}, instead got #{actual.length}"
-  end
-end
-
-RSpec::Matchers.define :match_table do |expected|
-  diffable
-
-  match do |actual|
-    @actual = actual.to_s.strip
-    @expected = expected.to_s.strip
-
-    @actual == @expected
-  end
-
-  failure_message do |actual|
-    <<~MSG
-      Expected:
-      #{with_whitespace_highlighted(expected.to_s.strip)}
-
-      Received:
-      #{with_whitespace_highlighted(actual.to_s.strip)}
-
-      Raw Result:
-      #{actual.to_s}
-    MSG
-  end
-
-  def with_whitespace_highlighted(string)
-    string.lines.map { |line| "'#{line.gsub("\n", "")}'" }.join("\n")
-  end
-end
-
 describe Rex::Text::Table do
   let(:formatter) do
     clazz = Class.new do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rex/text'
 
+Dir['./spec/support/**/*.rb'].each do |f|
+  require f.sub(%r{\./spec/}, '')
+end
+
 RSpec.configure do |config|
   if ENV['CI']
     config.before(:example, :focus) { raise "Should not commit focused specs" }

--- a/spec/support/matchers/have_maximum_width.rb
+++ b/spec/support/matchers/have_maximum_width.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :have_maximum_width do |expected|
+  match do |actual|
+    actual.length <= expected
+  end
+
+  failure_message do |actual|
+    "expected '#{actual}' to have a length than or equal to #{expected}, instead got #{actual.length}"
+  end
+end

--- a/spec/support/matchers/match_table.rb
+++ b/spec/support/matchers/match_table.rb
@@ -1,0 +1,27 @@
+RSpec::Matchers.define :match_table do |expected|
+  diffable
+
+  match do |actual|
+    @actual = actual.to_s.strip
+    @expected = expected.to_s.strip
+
+    @actual == @expected
+  end
+
+  failure_message do |actual|
+    <<~MSG
+      Expected:
+      #{with_whitespace_highlighted(expected.to_s.strip)}
+
+      Received:
+      #{with_whitespace_highlighted(actual.to_s.strip)}
+
+      Raw Result:
+      #{actual.to_s}
+    MSG
+  end
+
+  def with_whitespace_highlighted(string)
+    string.lines.map { |line| "'#{line.gsub("\n", "")}'" }.join("\n")
+  end
+end


### PR DESCRIPTION
I initially placed these custom rspec matchers at the top of the spec help that needed it for convenience.

I've now extracted these matchers into a separate spec file for convenience