### PR TITLE
Adding support for Rust formatted shellcode generation

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -87,6 +87,27 @@ module Rex
     end
 
     #
+    # Converts to a Rust style array of bytes
+    #
+    def self.to_rust(str, wrap = DefaultWrap, name = "buf")
+      ret = "let #{name}: Vec<u8> = vec!["
+      str.each_char do |char|
+        # "0x##,".length is 5, check if we're going over the wrap boundary
+        ret << "\n" if ret.split("\n").last.length + 5 > wrap
+        ret << "0x" << char.unpack('H*')[0] << ","
+      end
+      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
+      ret << "\n" if ret.split("\n").last.length + 2 > wrap
+      ret << "];\n"
+    
+    #
+    # Creates a Rust style comment
+    #
+    def self.to_rust_comment(str, wrap = DefaultWrap)
+      return "/*\n" + wordwrap(str, 0, wrap, '', ' * ') + " */\n"
+    end
+
+    #
     # Creates a c-style comment
     #
     def self.to_c_comment(str, wrap = DefaultWrap)

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -90,7 +90,7 @@ module Rex
     # Converts to a Rust style array of bytes
     #
     def self.to_rust(str, wrap = DefaultWrap, name = "buf")
-      ret = "let mut #{name}: Vec<u8> = vec!["
+      ret = "let #{name}: [u8; #{str.length}] = ["
       str.each_char do |char|
         # "0x##,".length is 5, check if we're going over the wrap boundary
         ret << "\n" if ret.split("\n").last.length + 5 > wrap

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -90,7 +90,7 @@ module Rex
     # Converts to a Rust style array of bytes
     #
     def self.to_rust(str, wrap = DefaultWrap, name = "buf")
-      ret = "let #{name}: Vec<u8> = vec!["
+      ret = "let mut #{name}: Vec<u8> = vec!["
       str.each_char do |char|
         # "0x##,".length is 5, check if we're going over the wrap boundary
         ret << "\n" if ret.split("\n").last.length + 5 > wrap

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -99,6 +99,7 @@ module Rex
       ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
       ret << "\n" if ret.split("\n").last.length + 2 > wrap
       ret << "];\n"
+    end
     
     #
     # Creates a Rust style comment

--- a/spec/rex/text/lang_spec.rb
+++ b/spec/rex/text/lang_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 RSpec.describe Rex::Text do
 
-  LANGUAGES = %w[ bash c csharp golang nim perl python ruby ]
+  LANGUAGES = %w[ bash c csharp golang nim rust perl python ruby ]
 
   context "to language methods should wrap at the specified columns" do
     LANGUAGES.each do |lang|


### PR DESCRIPTION
This PR adds support for Rust shellcode generation which supports both rust and rustlang formats. Please note that an [unmutable u8 array](https://doc.rust-lang.org/std/primitive.array.html) is created by default.

Example msfvenom Rust shellcode for calc.exe:

![msfvenom-calc](https://user-images.githubusercontent.com/89628341/199113699-e24c84f9-a377-42ed-bbda-9befcbe46b31.png)


Example msfconsole Rust shellcode for calc.exe:

![msfconsole-calc](https://user-images.githubusercontent.com/89628341/199113935-83d66d55-f42e-41f2-be7c-f6272bbc317e.png)


This has been tested with my own [Rust basic shellcode injector](https://github.com/memN0ps/arsenal-rs/tree/main/shellcode_runner_classic-rs)