### PR TITLE
Fix slow hexifying

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -28,30 +28,14 @@ module Rex
     end
 
     def self.to_csharp(str, wrap = DefaultWrap, name = "buf")
-      ret = "byte[] #{name} = new byte[#{str.length}] {"
-      str.each_char do |char|
-        # "0x##,".length is 5, check if we're going over the wrap boundary
-        ret << "\n" if ret.split("\n").last.length + 5 > wrap
-        ret << "0x" << char.unpack('H*')[0] << ","
-      end
-      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
-      ret << "\n" if ret.split("\n").last.length + 2 > wrap
-      ret << "};\n"
+      return numhexify(str, wrap, '', '',  "byte[] #{name} = new byte[#{str.length}] {", "};", ',')
     end
 
     #
     # Converts to a golang style array of bytes
     #
     def self.to_golang(str, wrap = DefaultWrap, name = "buf")
-      ret = "#{name} :=  []byte{"
-      str.each_char do |char|
-        # "0x##,".length is 5, check if we're going over the wrap boundary
-        ret << "\n" if ret.split("\n").last.length + 5 > wrap
-        ret << "0x" << char.unpack('H*')[0] << ","
-      end
-      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
-      ret << "\n" if ret.split("\n").last.length + 2 > wrap
-      ret << "};\n"
+      return numhexify(str, wrap, '', '',  "#{name} :=  []byte{", "};", ',')
     end
 
     #
@@ -66,17 +50,7 @@ module Rex
     #
     def self.to_nim(str, wrap = DefaultWrap, name = "buf")
       raise ArgumentError.new('str can not be empty') if str.empty?
-
-      ret = "var #{name}: array[#{str.length}, byte] = [\n"
-      ret << "byte "
-      str.each_char do |char|
-        # "0x##,".length is 5, check if we're going over the wrap boundary
-        ret << "\n" if ret.split("\n").last.length + 5 > wrap
-        ret << "0x" << char.unpack('H*')[0] << ","
-      end
-      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
-      ret << "\n" if ret.split("\n").last.length + 1 > wrap
-      ret << "]\n"
+      return numhexify(str, wrap, '', '',  "var #{name}: array[#{str.length}, byte] = [\nbyte ", "]", ',')
     end
 
     #
@@ -90,15 +64,7 @@ module Rex
     # Converts to a Rust style array of bytes
     #
     def self.to_rust(str, wrap = DefaultWrap, name = "buf")
-      ret = "let #{name}: [u8; #{str.length}] = ["
-      str.each_char do |char|
-        # "0x##,".length is 5, check if we're going over the wrap boundary
-        ret << "\n" if ret.split("\n").last.length + 5 > wrap
-        ret << "0x" << char.unpack('H*')[0] << ","
-      end
-      ret = ret[0..ret.length - 2] unless str.empty? # cut off last comma
-      ret << "\n" if ret.split("\n").last.length + 2 > wrap
-      ret << "];\n"
+      return numhexify(str, wrap, '', '',  "let #{name}: [u8; #{str.length}] = [", "];", ',')
     end
     
     #

--- a/spec/rex/text/hex_spec.rb
+++ b/spec/rex/text/hex_spec.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'spec_helper'
+require 'timeout'
 
 RSpec.describe Rex::Text do
   describe ".hexify" do
@@ -16,6 +17,12 @@ RSpec.describe Rex::Text do
 
     it 'should convert the buffer to hex' do
       expect(described_class.hexify(Random.bytes(8))).to match(/(\\x[a-fA-F0-9]{2}){8}/)
+    end
+
+    it 'should finish instantaneously' do
+      Timeout::timeout(5) do
+        described_class.hexify(Random.bytes(800000))
+      end
     end
   end
 end

--- a/spec/rex/text/lang_spec.rb
+++ b/spec/rex/text/lang_spec.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'spec_helper'
+require 'timeout'
 
 RSpec.describe Rex::Text do
 
@@ -12,6 +13,19 @@ RSpec.describe Rex::Text do
           wrap = 60
           lines = described_class.send("to_#{lang}", "A" * 100, wrap).split("\n")
           expect(lines).to all(have_maximum_width(wrap))
+        end
+      end
+    end
+  end
+
+  context "to language methods should complete almost instantaneously" do
+    LANGUAGES.each do |lang|
+      describe ".to_#{lang}" do
+        it "should not time out" do
+          wrap = 60
+          Timeout::timeout(5) do
+            described_class.send("to_#{lang}", "A" * 100000, wrap)
+          end
         end
       end
     end

--- a/spec/rex/text/lang_spec.rb
+++ b/spec/rex/text/lang_spec.rb
@@ -6,12 +6,106 @@ RSpec.describe Rex::Text do
 
   LANGUAGES = %w[ bash c csharp golang nim rust perl python ruby ]
 
+  describe "languages match expected output" do
+    let(:expected_bash) do
+      "export buf=\\\n$'\\x41\\x41\\x41\\x41\\x41\\x41'\\\n$'\\x41\\x41\\x41\\x41'\n"
+    end
+
+    let(:expected_c) do
+      "unsigned char buf[] = \n\"\\x41\\x41\\x41\\x41\\x41\\x41\\x41\"\n\"\\x41\\x41\\x41\";\n"
+    end
+
+    let(:expected_csharp) do
+      "byte[] buf = new byte[10] {\n0x41,0x41,0x41,0x41,0x41,0x41,\n0x41,0x41,0x41,0x41};\n"
+    end
+
+    let(:expected_golang) do
+      "buf :=  []byte{0x41,0x41,0x41,\n0x41,0x41,0x41,0x41,0x41,0x41,\n0x41};\n"
+    end
+
+    let(:expected_nim) do
+      "var buf: array[10, byte] = [\nbyte 0x41,0x41,0x41,0x41,0x41,\n0x41,0x41,0x41,0x41,0x41]\n"
+    end
+
+    let(:expected_rust) do
+      "let buf: [u8; 10] = [0x41,\n0x41,0x41,0x41,0x41,0x41,0x41,\n0x41,0x41,0x41];\n"
+    end
+
+    let(:expected_perl) do
+      "my $buf = \n\"\\x41\\x41\\x41\\x41\\x41\\x41\" .\n\"\\x41\\x41\\x41\\x41\";\n"
+    end
+
+    let(:expected_python) do
+      "buf =  b\"\"\nbuf += b\"\\x41\\x41\\x41\\x41\\x41\"\nbuf += b\"\\x41\\x41\\x41\\x41\\x41\"\n"
+    end
+
+    let(:expected_ruby) do
+      "buf = \n\"\\x41\\x41\\x41\\x41\\x41\\x41\" +\n\"\\x41\\x41\\x41\\x41\"\n"
+    end
+
+    it "bash is as expected" do
+      output = described_class.to_bash('A' * 10, 30)
+      expect(output).to eq(expected_bash)
+    end
+
+    it "c is as expected" do
+      output = described_class.to_c('A' * 10, 30)
+      expect(output).to eq(expected_c)
+    end
+
+    it "csharp is as expected" do
+      output = described_class.to_csharp('A' * 10, 30)
+      expect(output).to eq(expected_csharp)
+    end
+
+    it "golang is as expected" do
+      output = described_class.to_golang('A' * 10, 30)
+      expect(output).to eq(expected_golang)
+    end
+
+    it "nim is as expected" do
+      output = described_class.to_nim('A' * 10, 30)
+      expect(output).to eq(expected_nim)
+    end
+
+    it "rust is as expected" do
+      output = described_class.to_rust('A' * 10, 30)
+      expect(output).to eq(expected_rust)
+    end
+
+    it "perl is as expected" do
+      output = described_class.to_perl('A' * 10, 30)
+      expect(output).to eq(expected_perl)
+    end
+
+    it "python is as expected" do
+      output = described_class.to_python('A' * 10, 30)
+      expect(output).to eq(expected_python)
+    end
+
+    it "ruby is as expected" do
+      output = described_class.to_ruby('A' * 10, 30)
+      expect(output).to eq(expected_ruby)
+    end
+  end
+
+
   context "to language methods should wrap at the specified columns" do
     LANGUAGES.each do |lang|
       describe ".to_#{lang}" do
-        it "should raise on non-convertable characters" do
+        it "should wrap to 60" do
           wrap = 60
           lines = described_class.send("to_#{lang}", "A" * 100, wrap).split("\n")
+          expect(lines).to all(have_maximum_width(wrap))
+        end
+      end
+    end
+
+    LANGUAGES.each do |lang|
+      describe ".to_#{lang}" do
+        it "should wrap to the provided random value" do
+          wrap = rand(100)+40
+          lines = described_class.send("to_#{lang}", "A" * 1000, wrap).split("\n")
           expect(lines).to all(have_maximum_width(wrap))
         end
       end


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/17245.

For small payloads (on the order of a few thousand characters), it was relatively fine. But increase that to a stageless payload, and it got incredibly slow.

The root cause was a subtle computational complexity change introduced in https://github.com/rapid7/rex-text/pull/53. The use of `split` inside an `each_char` loop essentially turned it from linear into polynomial.

My approach to resolve this was to keep track of the length of the current last line, so no backtracking is required.

I also combined both the `\xNN` and the `0xNN` algorithms, since they were so similar, and the `0xNN` one was used by several languages in an almost identical manner.

I also wrote unit tests that verified that:

- The generated data is the same as it used to be (one example per language)
- It doesn't take too long (5 sec timeout - should be virtually instantaneous)
- The wrapping works with a random length as well as the fixed 60

Once this is landed, it should be pulled in to MSF framework to resolve the aforementioned issue.