### PR TITLE
metasploit services sorting issue when saved into csv file

### DIFF
--- a/lib/rex/text/wrapped_table.rb
+++ b/lib/rex/text/wrapped_table.rb
@@ -144,6 +144,8 @@ class WrappedTable
   # Converts table contents to a csv
   #
   def to_csv
+    sort_rows
+
     str = ''
     str << ( columns.join(",") + "\n" )
     rows.each { |row|

--- a/spec/rex/text/wrapped_table_spec.rb
+++ b/spec/rex/text/wrapped_table_spec.rb
@@ -82,9 +82,9 @@ describe Rex::Text::Table do
 
       expect(tbl.to_csv).to eql <<~TABLE.force_encoding("UTF-8")
         Name,Value
-        "hello world","hello world"
-        "Administratör","Administratör"
         "Administrator’s Shares","Administrator’s Shares"
+        "Administratör","Administratör"
+        "hello world","hello world"
         "这是中文这是中文这是中文这是中文","这是中文这是中文这是中文这是中文"
         "�_��\u0010\u007F\u0011N���:T3A�","四Ⅰ"
         "👍👍👍👍👍👍","hello 日本"


### PR DESCRIPTION
… passwords

Fixes [Metasploit issue 17714](https://github.com/rapid7/metasploit-framework/issues/17714) where the service command is not sorting the rows when it is getting saved into a csv file.

## Verification

Add some services before to test this.

- [x] Start `msfconsole`
- [x] use `services -u -O 1 -o output.csv`


Here is the sample of the output for the above command before fix.

```
msf6 > services -u -O 1 -o output.csv
[*] Wrote services to ~/git/metasploit-framework/output.csv
msf6 >
```
File output

```
cat ~/git/metasploit-framework/output.csv
host,port,proto,name,state,info
"147.124.211.125","80","tcp","http","open",""
"66.33.214.230","443","tcp","http","open",""
```

After the fix.

- [x] Start `msfconsole`
- [x] use `services -u -O 1 -o output.csv`

Here is the sample output for above data

```
msf6 > services -u -O 1 -o output.csv
[*] Wrote services to ~/git/metasploit-framework/output.csv
msf6 >
```

File Output.
```
cat ~/git/metasploit-framework/output.csv

host,port,proto,name,state,info
"66.33.214.230","443","tcp","http","open",""
"147.124.211.125","80","tcp","http","open",""
```
