### PR TITLE
add support to masm formatting

### DIFF
--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -46,6 +46,22 @@ module Rex
     end
 
     #
+    # Converts to a masm style array of bytes
+    #
+    def self.to_mas(str, wrap = DefaultWrap, name = "")
+      raise ArgumentError.new('str can not be empty') if str.empty?
+      a = to_hex(str)
+      a.gsub!(/\\x/, '')
+      a.gsub!(/(.{2})/, '\1h,')
+      a.gsub!(/(.{32})/, '\1\n')
+      a.gsub!('\n', "\n")
+      a.gsub!(/^(.*),$/, 'DB \1')
+      a.gsub!(/([a-f].h)/, '0\1')
+      a.sub!(/^/, 'shellcode ')
+      return a
+    end
+
+    #
     # Converts to a nim style array of bytes
     #
     def self.to_nim(str, wrap = DefaultWrap, name = "buf")

--- a/lib/rex/text/lang.rb
+++ b/lib/rex/text/lang.rb
@@ -48,7 +48,7 @@ module Rex
     #
     # Converts to a masm style array of bytes
     #
-    def self.to_mas(str, wrap = DefaultWrap, name = "")
+    def self.to_masm(str, wrap = DefaultWrap, name = "")
       raise ArgumentError.new('str can not be empty') if str.empty?
       a = to_hex(str)
       a.gsub!(/\\x/, '')


### PR DESCRIPTION
add the correct formating to insert shellcode inside a masm code.

```
(shellchocolat)➜ ➜ ~ cat nop.bin | msfvenom -p - -a x64 --platform windows -e x64/xor -f masm
Attempting to read payload from STDIN...
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x64/xor
x64/xor succeeded with size 55 (iteration=0)
x64/xor chosen with final size 55
Payload size: 55 bytes
Final size of masm file: 277 bytes
shellcode DB 48h,31h,0c9h,48h,81h,0e9h,0feh,0ffh
DB 0ffh,0ffh,48h,8dh,05h,0efh,0ffh,0ffh
DB 0ffh,48h,0bbh,0f5h,80h,0cbh,7eh,0f7h
DB 0bbh,0b3h,2bh,48h,31h,58h,27h,48h
DB 2dh,0f8h,0ffh,0ffh,0ffh,0e2h,0f4h,65h
DB 10h,5bh,0eeh,67h,2bh,23h,0bbh,65h
DB 10h,5bh,0eeh,67h,0bbh,0b3h,2bh
```

A pull request has been made to the metasploit-framework too.