### PR TITLE
Remove unused travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-group: stable
-cache: bundler
-language: ruby
-rvm:
-  - 2.7.2


### PR DESCRIPTION
This config file is unused, as it was replaced by Github actions