### PR TITLE
Allow opting out of whitespace removal

### DIFF
--- a/lib/rex/text/table.rb
+++ b/lib/rex/text/table.rb
@@ -21,21 +21,13 @@ class Table
   # To enforce all tables to be wrapped to the terminal's current width, call `Table.wrap_tables!`
   # before invoking `Table.new` as normal.
   def self.new(*args, &block)
-    if wrap_table?(args)
-      table_options = args.first
-      return ::Rex::Text::WrappedTable.new(table_options)
-    end
-    return super(*args, &block)
+    return super(*args, &block) unless wrap_table?(args)
+
+    table_options = args.first
+    ::Rex::Text::WrappedTable.new(table_options)
   end
 
   def self.wrap_table?(args)
-    return false unless wrapped_tables?
-
-    table_options = args.first
-    if table_options&.key?('WordWrap')
-      return table_options['WordWrap']
-    end
-
     wrapped_tables?
   end
 

--- a/spec/rex/text/table_spec.rb
+++ b/spec/rex/text/table_spec.rb
@@ -39,12 +39,12 @@ describe Rex::Text::Table do
         expect(described_class.wrap_table?(default_table_options)).to be true
       end
 
-      it "returns the user preference when set to true" do
+      it "ignores the user preference when set to true" do
         expect(described_class.wrap_table?(enable_wrapped_table_options)).to be true
       end
 
-      it "returns the user preference when set to false" do
-        expect(described_class.wrap_table?(disable_wrapped_table_options)).to be false
+      it "ignores the user preference when set to false" do
+        expect(described_class.wrap_table?(disable_wrapped_table_options)).to be true
       end
     end
 


### PR DESCRIPTION
Update rex-text to support disabling whitespace stripping by default